### PR TITLE
EUI-64 on CC2538

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/eui64.c
+++ b/firmware/openos/bsp/boards/cc2538/eui64.c
@@ -30,7 +30,7 @@ void eui64_get(uint8_t* addressToWrite) {
     }
 
     eui64_flash = BSP_EUI64_ADDRESS_HI_H;
-    while(eui64_flash > BSP_EUI64_ADDRESS_HI_L) {
+    while(eui64_flash >= BSP_EUI64_ADDRESS_HI_L) {
         *addressToWrite++ = *eui64_flash--;
     }
 }


### PR DESCRIPTION
Updated the eui64_get function for the CC2538 chip based on the memory mapping information provided by Texas Instruments. Please notice that the first commit has a bug which is fixed on the second commit.
