### PR TITLE
FW-177. Add cross-platform builds for simulation library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ settings
 *.so
 *.a
 *.pyd
+*.pyc
 path.txt
 /build
 /.sconsign.dblite
@@ -17,5 +18,6 @@ path.txt
 .directory
 /firmware/openos/projects/common/03oos_openwsn_prog
 /firmware/openos/projects/common/03oos_openwsn/03oos_openwsn_obj.*
+/firmware/openos/projects/common/oos_openwsn.*
 /firmware/openos/bsp/boards/python/openwsnmodule_obj.c
 /firmware/openos/bsp/boards/python/openwsnmodule_obj.os

--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 import SCons
 
 #============================ banner ==========================================
@@ -15,6 +16,68 @@ banner += [""]
 banner  = '\n'.join(banner)
 print banner
 
+#===== help text
+
+Help('''
+Usage:
+    scons [<variable>=<value> ...] <project>
+    scons docs
+    scons [help-option]
+
+project:
+    A project is represented by a subdirectory of the 
+    firmware{0}openos{0}projects directory, for a particular board. For 
+    example, the 'oos_openwsn' project may be built for telosb. To specify a 
+    project, exclude the leading digits in the directory name, like '03' for 
+    oos_openwsn.
+
+    variable=value pairs
+    These pairs qualify how the project is built, and are organized here into
+    functional groups. Below each variable's description are the valid 
+    options, with the default value listed first.
+    
+    board        Board to build for. 'python' is for software simulation.
+                 telosb, wsn430v14, wsn430v13b, gina, z1, pc, python
+        
+    toolchain    Toolchain implementation. The 'python' board requires gcc
+                 (MinGW on Windows build host).
+                 mspgcc, iar, iar-proj, gcc
+    
+    Connected hardware variables:
+    bootload     Location of the board to bootload the binary on. 
+                 COMx for Windows, /dev entries for Linux
+                 Supports parallel operation with a comma-separated list,
+                 for example 'COM5,COM6,COM7'.
+    jtag         Location of the board to JTAG the binary to.
+                 COMx for Windows, /dev entry for Linux
+    fet_version  Firmware version running on the MSP-FET430uif for jtag.
+                 2, 3
+    
+    Simulation variables:
+    fastsim      Compiles the firmware for fast simulation.
+                 1 (on), 0 (off)
+
+    These simulation variables are for a cross-platform build, and are valid
+    only from an amd64-linux build host.
+    simhost      Host platform and OS for simulation. Default selection is
+                 the current platform/OS, which of course is not a cross-
+                 build. x86-windows cross-build requires MinGW-w64 toolchain.
+                 amd64-linux, x86-linux, amd64-windows, x86-windows
+    simhostpy    Home directory for simhost cross-build Python headers and 
+                 shared library.
+    
+    Common variables:
+    verbose      Print each complete compile/link comand.
+                 0 (off), 1 (on)
+    
+docs:
+    Generate source documentation in build{0}docs{0}html directory
+
+help-option:
+    --help       Display help text. Also display when no parameters to the
+                 scons scommand.
+'''.format(os.sep))
+
 #============================ options =========================================
 
 #===== options
@@ -25,6 +88,8 @@ command_line_options = {
     'fet_version': ['2','3'],
     'verbose':     ['0','1'],
     'fastsim':     ['1','0'],
+    'simhost':     ['amd64-linux','x86-linux','amd64-windows','x86-windows'],
+    'simhostpy':   ['']                                # No reasonable default
 }
 
 def validate_option(key, value, env):
@@ -32,74 +97,101 @@ def validate_option(key, value, env):
        raise ValueError("Unknown switch {0}.".format(key))
     if value not in command_line_options[key]:
        raise ValueError("Unknown {0} \"{1}\". Options are {2}.\n\n".format(key,value,','.join(command_line_options[key])))
-    
+
+# Define default value for simhost option
+if os.name=='nt':
+    defaultHost = 2
+else:
+    defaultHost = 0 if platform.architecture()[0]=='64bit' else 1
+
 command_line_vars = Variables()
 command_line_vars.AddVariables(
     (
         'board',                                           # key
-        'Board to build for.',                             # help
+        '',                                                # help
         command_line_options['board'][0],                  # default
         validate_option,                                   # validator
         None,                                              # converter
     ),
     (
         'toolchain',                                       # key
-        'Toolchain to use.',                               # help
+        '',                                                # help
         command_line_options['toolchain'][0],              # default
         validate_option,                                   # validator
         None,                                              # converter
     ),
     (
         'jtag',                                            # key
-        'Location of the board to JTAG the binary to.',    # help
+        '',                                                # help
         '',                                                # default
         None,                                              # validator
         None,                                              # converter
     ),
     (
         'fet_version',                                     # key
-        'Firmware version running on the MSP-FET430uif.',  # help
+        '',                                                # help
         command_line_options['fet_version'][0],            # default
         validate_option,                                   # validator
         int,                                               # converter
     ),
     (
         'bootload',                                        # key
-        'Location of the board to bootload the binary on.',# help
+        '',                                                # help
         '',                                                # default
         None,                                              # validator
         None,                                              # converter
     ),
     (
         'verbose',                                         # key
-        'Print complete compile/link comand.',             # help
+        '',                                                # help
         command_line_options['verbose'][0],                # default
         validate_option,                                   # validator
         int,                                               # converter
     ),
     (
         'fastsim',                                         # key
-        'Compiles the firmware for fast simulation.',      # help
+        '',                                                # help
         command_line_options['fastsim'][0],                # default
         validate_option,                                   # validator
         int,                                               # converter
+    ),
+    (
+        'simhost',                                         # key
+        '',                                                # help
+        command_line_options['simhost'][defaultHost],      # default
+        validate_option,                                   # validator
+        None,                                              # converter
+    ),
+    (
+        'simhostpy',                                       # key
+        '',                                                # help
+        command_line_options['simhostpy'][0],              # default
+        None,                                              # validator
+        None,                                              # converter
     ),
 )
 
 if os.name=='nt':
     env = Environment(
         tools     = ['mingw'],
-        variables = command_line_vars,
+        variables = command_line_vars
     )
 else:
-    env = Environment(
-        variables = command_line_vars,
-    )
+    simhost = ARGUMENTS.get('simhost', 'none')
+    board   = ARGUMENTS.get('board', 'none')
+    if board=='python' and simhost.endswith('-windows'):
+        # Cross-compile for simulation on Windows
+        env = Environment(
+            # crossMingw64 requires 'mingw_prefer_amd64' key
+            tools              = ['crossMingw64'],
+            mingw_prefer_amd64 = simhost.startswith('amd64-'),
+            variables          = command_line_vars
+        )
+    else:
+        env = Environment(
+            variables = command_line_vars
+        )
 
-#===== help text
-
-Help("\nUsage: scons board=<b> toolchain=<tc> project\n\nWhere:")
-Help(command_line_vars.GenerateHelpText(env))
 def default(env,target,source): print SCons.Script.help_text
 Default(env.Command('default', None, default))
 

--- a/firmware/openos/bsp/boards/python/openwsnmodule.c
+++ b/firmware/openos/bsp/boards/python/openwsnmodule.c
@@ -76,19 +76,19 @@ static PyObject* OpenMote_getState(OpenMote* self) {
    returnVal = PyDict_New();
    
    // callbacks
-   uart_icb_tx                    = PyInt_FromLong((long)self->uart_icb.txCb);
+   uart_icb_tx                    = PyInt_FromLong((intptr_t)self->uart_icb.txCb);
    PyDict_SetItemString(returnVal, "uart_icb_tx", uart_icb_tx);
-   uart_icb_rx                    = PyInt_FromLong((long)self->uart_icb.rxCb);
+   uart_icb_rx                    = PyInt_FromLong((intptr_t)self->uart_icb.rxCb);
    PyDict_SetItemString(returnVal, "uart_icb_rx", uart_icb_rx);
-   bsp_timer_icb_cb               = PyInt_FromLong((long)self->bsp_timer_icb.cb);
+   bsp_timer_icb_cb               = PyInt_FromLong((intptr_t)self->bsp_timer_icb.cb);
    PyDict_SetItemString(returnVal, "bsp_timer_icb_cb", bsp_timer_icb_cb);
-   radio_icb_startFrame_cb        = PyInt_FromLong((long)self->radio_icb.startFrame_cb);
+   radio_icb_startFrame_cb        = PyInt_FromLong((intptr_t)self->radio_icb.startFrame_cb);
    PyDict_SetItemString(returnVal, "radio_icb_startFrame_cb", radio_icb_startFrame_cb);
-   radio_icb_endFrame_cb          = PyInt_FromLong((long)self->radio_icb.endFrame_cb);
+   radio_icb_endFrame_cb          = PyInt_FromLong((intptr_t)self->radio_icb.endFrame_cb);
    PyDict_SetItemString(returnVal, "radio_icb_endFrame_cb", radio_icb_endFrame_cb   );
-   radiotimer_icb_overflow_cb     = PyInt_FromLong((long)self->radiotimer_icb.overflow_cb);
+   radiotimer_icb_overflow_cb     = PyInt_FromLong((intptr_t)self->radiotimer_icb.overflow_cb);
    PyDict_SetItemString(returnVal, "radiotimer_icb_overflow_cb", radiotimer_icb_overflow_cb);
-   radiotimer_icb_compare_cb      = PyInt_FromLong((long)self->radiotimer_icb.compare_cb);
+   radiotimer_icb_compare_cb      = PyInt_FromLong((intptr_t)self->radiotimer_icb.compare_cb);
    PyDict_SetItemString(returnVal, "radiotimer_icb_compare_cb", radiotimer_icb_compare_cb);
    
    // ohlone_vars

--- a/firmware/openos/projects/python/SConscript.env
+++ b/firmware/openos/projects/python/SConscript.env
@@ -1,6 +1,8 @@
 import os
 import datetime
 import re
+import platform
+import sconsUtils
 
 import distutils.sysconfig
 
@@ -17,10 +19,38 @@ buildEnv['ENV'] = os.environ
 # configuration for the same board.
 buildEnv['BSP'] = buildEnv['board']
 
+# Define locations for Python headers and shared library. A cross-platform build
+# requires environment variables for these locations.
+isCrossBuild = False
+if os.name!='nt':
+    if platform.architecture()[0]=='64bit' and buildEnv['simhost']=='x86-linux':
+        # Search for a well-known file in the include directory tree to avoid 
+        # hard-coding the intervening directories, which may refer to the build host
+        # or Python version. For example, on the author's system, the file is in the
+        # 'i386-linux-gnu/python2.7' directory.
+        isCrossBuild = True
+        pathnames    = sconsUtils.findPattern('Python.h',
+                                              '{0}/include'.format(buildEnv['simhostpy']))
+        if pathnames:
+            pathname = pathnames[0]
+        else:
+            raise SystemError("Can't find python header in 'include' directory below provided simhostpy")
+        pythonInc    = os.path.dirname(pathname)
+        pythonLib    = '{0}/lib'.format(buildEnv['simhostpy'])
+        
+    elif buildEnv['simhost'].endswith('-windows'):
+        isCrossBuild = True
+        pythonInc    = buildEnv['simhostpy']
+        pythonLib    = buildEnv['simhostpy']
+    
+if not isCrossBuild:
+    pythonInc = distutils.sysconfig.get_python_inc()
+    pythonLib = distutils.sysconfig.PREFIX+"/libs"
+    
 # update C include path
 buildEnv.Append(
     CPPPATH = [
-        distutils.sysconfig.get_python_inc(),
+        pythonInc,
         os.path.join('#','build','python_gcc','bsp','boards'),
         os.path.join('#','build','python_gcc','bsp','boards','python'),
         os.path.join('#','build','python_gcc','drivers','common'),
@@ -56,7 +86,7 @@ buildEnv.Append(
 
 # update library include path
 buildEnv.Append(
-    LIBPATH = [distutils.sysconfig.PREFIX+"/libs"],
+    LIBPATH = [pythonLib],
 )
 
 #============================ objectify functions =============================

--- a/site_scons/sconsUtils.py
+++ b/site_scons/sconsUtils.py
@@ -1,0 +1,36 @@
+import os
+import fnmatch
+from SCons.Script import *
+
+'''
+Includes common SCons utilities, usable by SConstruct and any SConscript.
+'''
+
+def printEnv(env):
+    '''Prints provided SCons environment'''
+    envDict = env.Dictionary()
+    envKeys = envDict.keys()
+    envKeys.sort()
+    
+    print 'Environment Contents'
+    print '===================='
+    for key in envKeys:
+        print '* {0}\n  {1}'.format(key, envDict[key])
+
+
+def findPattern(pattern, path):
+    '''
+    Finds the files matching the provided pattern in the directory tree rooted
+    at the provided path.
+
+    :returns: List of the files found
+    '''
+    #for root, dirs, files in os.walk(path):
+    #    if name in files:
+    #        return os.path.join(root, name)
+    result = []
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            if fnmatch.fnmatch(name, pattern):
+                result.append(os.path.join(root, name))
+    return result

--- a/site_scons/site_tools/crossMingw64.py
+++ b/site_scons/site_tools/crossMingw64.py
@@ -1,0 +1,155 @@
+"""
+Tool-specific initialization for MinGW (http://www.mingw.org/)
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+Copied from http://www.scons.org/wiki/CrossCompilingMingw.
+"""
+import os
+import os.path
+
+import SCons.Action
+import SCons.Builder
+import SCons.Tool
+import SCons.Util
+
+def find(env):
+    prefixes = ['i686-w64-mingw32-']
+    try:
+        if env['mingw_prefer_amd64']:
+            prefixes.insert(0, 'x86_64-w64-mingw32-')
+            print "Inserted amd64 prefix"
+    except KeyError:
+        pass
+    print "prefixes list len {0}".format(len(prefixes))
+        
+    for prefix in prefixes:
+        # First search in the SCons path and then the OS path:
+        if env.WhereIs(prefix + 'gcc') or SCons.Util.WhereIs(prefix + 'gcc'):
+            return prefix
+
+    return ''
+
+def shlib_generator(target, source, env, for_signature):
+    cmd = SCons.Util.CLVar(['$SHLINK', '$SHLINKFLAGS'])
+
+    dll = env.FindIxes(target, 'SHLIBPREFIX', 'SHLIBSUFFIX')
+    if dll: cmd.extend(['-o', dll])
+
+    cmd.extend(['$SOURCES', '$_LIBDIRFLAGS', '$_LIBFLAGS'])
+
+    implib = env.FindIxes(target, 'LIBPREFIX', 'LIBSUFFIX')
+    if implib:
+        cmd.append('-Wl,--out-implib,'+implib.get_string(for_signature))
+
+    def_target = env.FindIxes(target, 'WIN32DEFPREFIX', 'WIN32DEFSUFFIX')
+    if def_target:
+        cmd.append('-Wl,--output-def,'+def_target.get_string(for_signature))
+
+    return [cmd]
+
+def shlib_emitter(target, source, env):
+    dll = env.FindIxes(target, 'SHLIBPREFIX', 'SHLIBSUFFIX')
+    no_import_lib = env.get('no_import_lib', 0)
+
+    if not dll:
+        raise SCons.Errors.UserError, "A shared library should have exactly one target with the suffix: %s" % env.subst("$SHLIBSUFFIX")
+
+    if not no_import_lib and \
+       not env.FindIxes(target, 'LIBPREFIX', 'LIBSUFFIX'):
+
+        # Append an import library to the list of targets.
+        target.append(env.ReplaceIxes(dll,
+                        'SHLIBPREFIX', 'SHLIBSUFFIX',
+                        'LIBPREFIX', 'LIBSUFFIX'))
+
+    # Append a def file target if there isn't already a def file target
+    # or a def file source. There is no option to disable def file
+    # target emitting, because I can't figure out why someone would ever
+    # want to turn it off.
+    def_source = env.FindIxes(source, 'WIN32DEFPREFIX', 'WIN32DEFSUFFIX')
+    def_target = env.FindIxes(target, 'WIN32DEFPREFIX', 'WIN32DEFSUFFIX')
+    if not def_source and not def_target:
+        target.append(env.ReplaceIxes(dll,
+                      'SHLIBPREFIX', 'SHLIBSUFFIX',
+                      'WIN32DEFPREFIX', 'WIN32DEFSUFFIX'))
+
+    return (target, source)
+
+
+#shlib_action = SCons.Action.CommandGenerator(shlib_generator)
+# in Scons 2.1 the line above needs to be replace with:
+shlib_action = SCons.Action.Action(shlib_generator, generator=1)
+
+res_action = SCons.Action.Action('$RCCOM', '$RCCOMSTR')
+
+res_builder = SCons.Builder.Builder(action=res_action, suffix='.o',
+                  source_scanner=SCons.Tool.SourceFileScanner)
+SCons.Tool.SourceFileScanner.add_scanner('.rc', SCons.Defaults.CScan)
+
+def generate(env):
+    mingw_prefix = find(env)
+
+    if mingw_prefix:
+        dir = os.path.dirname(env.WhereIs(mingw_prefix + 'gcc') or SCons.Util.WhereIs(mingw_prefix + 'gcc'))
+
+        # The mingw bin directory must be added to the path:
+        path = env['ENV'].get('PATH', [])
+        if not path:
+            path = []
+        if SCons.Util.is_String(path):
+            path = path.split(os.pathsep)
+
+        env['ENV']['PATH'] = os.pathsep.join([dir] + path)
+
+    # Most of mingw is the same as gcc and friends...
+    gnu_tools = ['gcc', 'g++', 'gnulink', 'ar', 'gas']
+    for tool in gnu_tools:
+        SCons.Tool.Tool(tool)(env)
+
+    #... but a few things differ:
+    env['CC'] = mingw_prefix + 'gcc'
+    env['SHCCFLAGS'] = SCons.Util.CLVar('$CCFLAGS')
+    env['CXX'] = mingw_prefix + 'g++'
+    env['SHCXXFLAGS'] = SCons.Util.CLVar('$CXXFLAGS')
+    env['SHLINKFLAGS'] = SCons.Util.CLVar('$LINKFLAGS -shared')
+    env['SHLINKCOM']   = shlib_action
+    env.Append(SHLIBEMITTER = [shlib_emitter])
+    # This line isn't required and breaks C++ linking
+    #env['LINK'] = mingw_prefix + 'g++'
+    env['AS'] = mingw_prefix + 'as'
+    env['AR'] = mingw_prefix + 'ar'
+    env['RANLIB'] = mingw_prefix + 'ranlib'
+    env['WIN32DEFPREFIX']    = ''
+    env['WIN32DEFSUFFIX']    = '.def'
+    env['SHOBJSUFFIX'] = '.o'
+    env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
+
+    env['RC'] = mingw_prefix + 'windres'
+    env['RCFLAGS'] = SCons.Util.CLVar('')
+    env['RCINCFLAGS'] = '$( ${_concat(RCINCPREFIX, CPPPATH, RCINCSUFFIX, __env__, RDirs, TARGET)} $)'
+    env['RCINCPREFIX'] = '--include-dir '
+    env['RCINCSUFFIX'] = ''
+    env['RCCOM'] = '$RC $RCINCFLAGS $RCINCPREFIX $SOURCE.dir $RCFLAGS -i $SOURCE -o $TARGET'
+    env['BUILDERS']['RES'] = res_builder
+
+    # Some setting from the platform also have to be overridden:
+    env['OBJPREFIX']    = ''
+    env['OBJSUFFIX']    = '.o'
+    env['LIBPREFIX']    = 'lib'
+    env['LIBSUFFIX']    = '.a'
+    env['SHOBJPREFIX']  = '$OBJPREFIX'
+    env['SHOBJSUFFIX']  = '$OBJSUFFIX'
+    env['PROGPREFIX']   = ''
+    env['PROGSUFFIX']   = '.exe'
+    env['LIBPREFIX']    = ''
+    env['LIBSUFFIX']    = '.lib'
+    env['SHLIBPREFIX']  = ''
+    env['SHLIBSUFFIX']  = '.dll'
+    env['LIBPREFIXES']  = [ '$LIBPREFIX' ]
+    env['LIBSUFFIXES']  = [ '$LIBSUFFIX' ]
+
+def exists(env):
+    return find(env)


### PR DESCRIPTION
- Supports x86-linux, amd64-windows, and x86-windows target build from an
  amd64-linux host, using MinGW-w64.
- Added two SCons build variables:
  - simhost   - simulation host architecture/OS to build
  - simhostpy - location of simulation host Python headers and library
- Added Scons tool module for MinGW-w64 support, and added SCons utils
  module.
- Reformatted SCons help text and provided more informative descriptions.
