### PR TITLE
Several fixes to the CC2538 bsp

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/board.c
+++ b/firmware/openos/bsp/boards/cc2538/board.c
@@ -24,16 +24,26 @@
 #include "hw_types.h"
 #include "hw_memmap.h"
 
-
-
 //=========================== variables =======================================
 
+#define BSP_RADIO_BASE              ( GPIO_D_BASE )
+#define BSP_RADIO_INT               ( GPIO_PIN_5 )
+#define BSP_RADIO_EXT               ( GPIO_PIN_4 )
+
 //=========================== prototypes ======================================
-void clockInit(uint32_t ui32SysClockSpeed);
-void SysCtrlDeepSleepSetting(void);
-void SysCtrlSleepSetting(void);
-void SysCtrlRunSetting(void);
-void SysCtrlWakeupSetting(void);
+
+void antenna_init();
+void antenna_internal();
+void antenna_external();
+
+static void clock_init(void);
+static void gpio_init(void);
+
+static void SysCtrlDeepSleepSetting(void);
+static void SysCtrlSleepSetting(void);
+static void SysCtrlRunSetting(void);
+static void SysCtrlWakeupSetting(void);
+
 //=========================== main ============================================
 
 extern int mote_main();
@@ -45,22 +55,11 @@ int main() {
 //=========================== public ==========================================
 
 void board_init() {
-   clockInit(SYS_CTRL_32MHZ);
+   gpio_init();
+   clock_init();
 
-   GPIOPinTypeGPIOOutput(GPIO_A_BASE, 0xFF);
-   GPIOPinTypeGPIOOutput(GPIO_B_BASE, 0xFF);
-   GPIOPinTypeGPIOOutput(GPIO_C_BASE, 0xFF);
-   GPIOPinTypeGPIOOutput(GPIO_D_BASE, 0xFF);
-
-   GPIOPinWrite(GPIO_A_BASE, 0xFF, 0);//initialize GPIOs to low
-   GPIOPinWrite(GPIO_B_BASE, 0xFF, 0);//initialize GPIOs to low
-   GPIOPinWrite(GPIO_C_BASE, 0xFF, 0);//initialize GPIOs to low
-   GPIOPinWrite(GPIO_D_BASE, 0xFF, 0);//initialize GPIOs to low
-
-   //antenna sel-- use PD4 or PD5
-   GPIOPinTypeGPIOOutput(GPIO_D_BASE, GPIO_PIN_4|GPIO_PIN_5);
-   GPIOPinWrite(GPIO_D_BASE, GPIO_PIN_5, GPIO_PIN_5);//use antenna pin 5 .. antenna 1
-   GPIOPinWrite(GPIO_D_BASE, GPIO_PIN_4, ~GPIO_PIN_4);//disable antenna pin 4 ..
+   antenna_init();
+   antenna_external();
 
    leds_init();
    debugpins_init();
@@ -72,106 +71,103 @@ void board_init() {
    leds_debug_on();
 }
 
-void board_sleep() {
-  SysCtrlSleep();
+/**
+ * Configures the antenna using a RF switch
+ * INT is the internal antenna (chip) configured through ANT1_SEL (V1)
+ * EXT is the external antenna (connector) configured through ANT2_SEL (V2)
+ */
+void antenna_init(void) {
+    // Configure the ANT1 and ANT2 GPIO as output
+    GPIOPinTypeGPIOOutput(BSP_RADIO_BASE, BSP_RADIO_INT);
+    GPIOPinTypeGPIOOutput(BSP_RADIO_BASE, BSP_RADIO_EXT);
+
+    // By default the chip antenna is selected as the default
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_INT, BSP_RADIO_INT);
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_EXT, ~BSP_RADIO_EXT);
 }
 
+/**
+ * Selects the external (connector) antenna
+ */
+void antenna_external(void) {
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_EXT, BSP_RADIO_EXT);
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_INT, ~BSP_RADIO_INT);
+}
+
+/**
+ * Selects the internal (chip) antenna
+ */
+void antenna_internal(void) {
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_EXT, ~BSP_RADIO_EXT);
+    GPIOPinWrite(BSP_RADIO_BASE, BSP_RADIO_INT, BSP_RADIO_INT);
+}
+
+/**
+ * Puts the board to sleep
+ */
+void board_sleep() {
+    SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
+    SysCtrlSleep();
+}
+
+/**
+ * Resets the board
+ */
 void board_reset() {
 	SysCtrlReset();
 }
 
 //=========================== private =========================================
 
-
-/**************************************************************************//**
-* @brief    Function initializes the CC2538 clocks and I/O for use on
-*           SmartRF06EB.
-*
-*           The function assumes an external crystal oscillator to be available
-*           to the CC2538. The CC2538 system clock is set to the frequency given
-*           by input argument \c ui32SysClockSpeed. The clock speed of other
-*           internal clocks are set to the maximum value allowed based on the
-*           system clock speed given by \c ui32SysClockSpeed.
-*
-*           If the value of \c ui32SysClockSpeed is invalid, the system clock
-*           will be set to the highest allowed value.
-*
-* @param    ui32SysClockSpeed   The system clock speed in Hz. Must be one of
-*                               the following:
-*           \li \c SYS_CTRL_32MHZ
-*           \li \c SYS_CTRL_16MHZ
-*           \li \c SYS_CTRL_8MHZ
-*           \li \c SYS_CTRL_4MHZ
-*           \li \c SYS_CTRL_2MHZ
-*           \li \c SYS_CTRL_1MHZ
-*           \li \c SYS_CTRL_500KHZ
-*           \li \c SYS_CTRL_250KHZ
-*
-* @return   None
-******************************************************************************/
-void clockInit(uint32_t ui32SysClockSpeed)
+static void gpio_init(void)
 {
-    uint32_t ui32SysDiv;
+    /* Set GPIOs as output */
+    GPIOPinTypeGPIOOutput(GPIO_A_BASE, 0xFF);
+    GPIOPinTypeGPIOOutput(GPIO_B_BASE, 0xFF);
+    GPIOPinTypeGPIOOutput(GPIO_C_BASE, 0xFF);
+    GPIOPinTypeGPIOOutput(GPIO_D_BASE, 0xFF);
 
-    //
-    // Disable global interrupts
-    //
+    /* Initialize GPIOs to low */
+    GPIOPinWrite(GPIO_A_BASE, 0xFF, 0x00);
+    GPIOPinWrite(GPIO_B_BASE, 0xFF, 0x00);
+    GPIOPinWrite(GPIO_C_BASE, 0xFF, 0x00);
+    GPIOPinWrite(GPIO_D_BASE, 0xFF, 0x00);
+}
+
+static void clock_init(void)
+{
+    /**
+     * Disable global interrupts
+     */
     bool bIntDisabled = IntMasterDisable();
 
-    //
-    // Determine sys clock divider and realtime clock
-    //
-    switch(ui32SysClockSpeed)
-    {
-    case SYS_CTRL_250KHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_250KHZ;
-        break;
-    case SYS_CTRL_500KHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_500KHZ;
-        break;
-    case SYS_CTRL_1MHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_1MHZ;
-        break;
-    case SYS_CTRL_2MHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_2MHZ;
-        break;
-    case SYS_CTRL_4MHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_4MHZ;
-        break;
-    case SYS_CTRL_8MHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_8MHZ;
-        break;
-    case SYS_CTRL_16MHZ:
-        ui32SysDiv = SYS_CTRL_SYSDIV_16MHZ;
-        break;
-    case SYS_CTRL_32MHZ:
-    default:
-        ui32SysDiv = SYS_CTRL_SYSDIV_32MHZ;
-        break;
-    }
+    /**
+     * Set the system clock to use the external 32 MHz crystal
+     * Set the real-time clock to use the 32khz internal crystal
+     */
+    SysCtrlClockSet(false, false, SYS_CTRL_SYSDIV_32MHZ);
 
-    //
-    // Set system clock and realtime clock
-    // use the 32khz external crystal
-    //
-    SysCtrlClockSet(false, false, ui32SysDiv);
+    /**
+     * Set the IO clock to use the internal 16 MHz clock (PIOSC)
+     */
+    SysCtrlIOClockSet(SYS_CTRL_SYSDIV_16MHZ);
 
-    //
-    // Set IO clock to the same as system clock
-    //
-    SysCtrlIOClockSet(ui32SysDiv);
-
+    /**
+     * Wait until the selected clock configuration is stable
+     */
     while ( !((HWREG(SYS_CTRL_CLOCK_STA)) & (SYS_CTRL_CLOCK_STA_XOSC_STB)));
 
-    //define what peripherals run at each mode.
+    /**
+     * Define what peripherals run in each mode
+     */
     SysCtrlDeepSleepSetting();
     SysCtrlSleepSetting();
     SysCtrlRunSetting();
     SysCtrlWakeupSetting();
 
-    //
-    // Re-enable interrupt if initially enabled.
-    //
+    /**
+     * Re-enable interrupt if initially enabled.
+     */
     if(!bIntDisabled)
     {
         IntMasterEnable();
@@ -179,7 +175,7 @@ void clockInit(uint32_t ui32SysClockSpeed)
 }
 
 
-void SysCtrlDeepSleepSetting(void)
+static void SysCtrlDeepSleepSetting(void)
 {
   /* Disable General Purpose Timers 0, 1, 2, 3 during deep sleep */
   SysCtrlPeripheralDeepSleepDisable(SYS_CTRL_PERIPH_GPT0);
@@ -199,15 +195,10 @@ void SysCtrlDeepSleepSetting(void)
   SysCtrlPeripheralDeepSleepDisable(SYS_CTRL_PERIPH_I2C);
   SysCtrlPeripheralDeepSleepDisable(SYS_CTRL_PERIPH_PKA);
   SysCtrlPeripheralDeepSleepDisable(SYS_CTRL_PERIPH_AES);
-
-  /*
-   * Enable RF Core during deep sleep. Please note that this setting is
-   * only valid for PG2.0. For PG1.0 this is just a dummy instruction.
-   */
-  SysCtrlPeripheralDeepSleepEnable(SYS_CTRL_PERIPH_RFC);
+  SysCtrlPeripheralDeepSleepDisable(SYS_CTRL_PERIPH_RFC);
 }
 
-void SysCtrlSleepSetting(void)
+static void SysCtrlSleepSetting(void)
 {
   /* Disable General Purpose Timers 0, 1, 2, 3 during sleep */
   SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_GPT0);
@@ -220,7 +211,6 @@ void SysCtrlSleepSetting(void)
   SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_SSI1);
 
   /* Disable UART 0, 1 during sleep */
-  SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_UART0);
   SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_UART1);
 
   /* Disable I2C, PKA, AES during sleep */
@@ -228,43 +218,34 @@ void SysCtrlSleepSetting(void)
   SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_PKA);
   SysCtrlPeripheralSleepDisable(SYS_CTRL_PERIPH_AES);
 
-  /*
-   * Enable RFC during sleep. Please note that this setting is
-   * only valid for PG2.0. For PG1.0 this is just a dummy instruction.
-   */
+  /* Enable UART and RFC during sleep */
+  SysCtrlPeripheralSleepEnable(SYS_CTRL_PERIPH_UART0);
   SysCtrlPeripheralSleepEnable(SYS_CTRL_PERIPH_RFC);
 }
 
 
 void SysCtrlRunSetting(void)
 {
-  /* Enable General Purpose Timers 0, 1, 2, 3 when running */
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_GPT0);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_GPT1);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_GPT2);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_GPT3);
+  /* Disable General Purpose Timers 0, 1, 2, 3 when running */
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_GPT0);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_GPT1);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_GPT2);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_GPT3);
 
-  /* Enable SSI 0, 1 when running */
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_SSI0);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_SSI1);
+  /* Disable SSI 0, 1 when running */
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_SSI0);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_SSI1);
 
-  /* Enable UART 0, 1 when running */
+  /* Disable UART1 when running */
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_UART1);
+
+  /* Disable I2C, AES and PKA when running */
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_I2C);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_PKA);
+  SysCtrlPeripheralDisable(SYS_CTRL_PERIPH_AES);
+
+  /* Enable UART0 and RFC when running */
   SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_UART0);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_UART1);
-
-  SysCtrlPeripheralReset(SYS_CTRL_PERIPH_AES);
-  SysCtrlPeripheralReset(SYS_CTRL_PERIPH_PKA);
-
-  /* Enable I2C, AES and PKA running */
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_I2C);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_PKA);
-  SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_AES);
-
-  /*
-   * Enable RFC during run. Please note that this setting is
-   * only valid for PG2.0. For PG1.0 since the RFC is always on,
-   * this is only a dummy  instruction
-   */
   SysCtrlPeripheralEnable(SYS_CTRL_PERIPH_RFC);
 }
 
@@ -272,8 +253,5 @@ void SysCtrlRunSetting(void)
 void SysCtrlWakeupSetting(void)
 {
   /* SM Timer can wake up the processor */
-
   GPIOIntWakeupEnable(GPIO_IWE_SM_TIMER);
-
-
 }

--- a/firmware/openos/bsp/boards/cc2538/radio.c
+++ b/firmware/openos/bsp/boards/cc2538/radio.c
@@ -374,7 +374,7 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
     // - *[2B]     CRC
 
   //skip first byte is len
-    for(i = 1; i < len; i++) {
+    for(i = 0; i < len - 2; i++) {
           pBufRead[i] = HWREG(RFCORE_SFR_RFDATA);
     }
 

--- a/firmware/openos/bsp/boards/cc2538/startup_gcc.c
+++ b/firmware/openos/bsp/boards/cc2538/startup_gcc.c
@@ -38,6 +38,8 @@
 
 #include <stdint.h>
 
+#include "hw_nvic.h"
+
 #define FLASH_START_ADDR                0x00200000
 #define BOOTLOADER_BACKDOOR_DISABLE     0xEFFFFFFF
 #define SYS_CTRL_EMUOVR                 0x400D20B4
@@ -319,7 +321,7 @@ ResetISR (void)
 
 
     /* Workaround for J-Link debug issue */
-   // HWREG(NVIC_VTABLE) = (uint32_t)gVectors;
+    HWREG(NVIC_VTABLE) = (uint32_t)gVectors;
 
     //
 	// Copy the data segment initializers from flash to SRAM.

--- a/firmware/openos/bsp/boards/cc2538/uart.c
+++ b/firmware/openos/bsp/boards/cc2538/uart.c
@@ -22,8 +22,10 @@
 #include "debugpins.h"
 
 //=========================== defines =========================================
-#define PIN_UART_RXD            GPIO_PIN_0 //PA0 is UART rx
-#define PIN_UART_TXD            GPIO_PIN_1 //PA1 is UART tx
+
+#define PIN_UART_RXD            GPIO_PIN_0 // PA0 is UART RX
+#define PIN_UART_TXD            GPIO_PIN_1 // PA1 is UART TX
+
 //=========================== variables =======================================
 
 typedef struct {
@@ -32,21 +34,25 @@ typedef struct {
 } uart_vars_t;
 
 uart_vars_t uart_vars;
-uint8_t i=0;
+
 //=========================== prototypes ======================================
-void uart_isr_private(void);
+
+static void uart_isr_private(void);
+
 //=========================== public ==========================================
 
 void uart_init() {
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
-   
+
    // Disable UART function
    UARTDisable(UART0_BASE);
+
    // Disable all UART module interrupts
    UARTIntDisable(UART0_BASE, 0x1FFF);
+
    // Set IO clock as UART clock source
-   UARTClockSourceSet(UART0_BASE, UART_CLOCK_SYSTEM);
+   UARTClockSourceSet(UART0_BASE, UART_CLOCK_PIOSC);
 
    // Map UART signals to the correct GPIO pins and configure them as
    // hardware controlled. GPIO-A pin 0 and 1
@@ -59,95 +65,94 @@ void uart_init() {
    // This function uses SysCtrlClockGet() to get the system clock
    // frequency.  This could be also be a variable or hard coded value
    // instead of a function call.
-   UARTConfigSetExpClk(UART0_BASE, SysCtrlClockGet(), 115200,
+   UARTConfigSetExpClk(UART0_BASE, SysCtrlIOClockGet(), 115200,
                       (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
                        UART_CONFIG_PAR_NONE));
 
-
-   // Set the UART to interrupt whenever the TX FIFO is almost empty or
-   // when any character is received.
-   //UARTFIFOLevelSet(UART0_BASE, UART_FIFO_TX1_8, UART_FIFO_RX1_8);
-   //enable UART hardware
+   // Enable UART hardware
    UARTEnable(UART0_BASE);
 
-   //disable FIFO as we only one 1byte buffer
+   // Disable FIFO as we only one 1byte buffer
    UARTFIFODisable(UART0_BASE);
 
-   //raise interrupt at end of tx (not by fifo)
+   // Raise interrupt at end of tx (not by fifo)
    UARTTxIntModeSet(UART0_BASE,UART_TXINT_MODE_EOT);
 
-   //register isr in the nvic and enable isr at the nvic
-
+   // Register isr in the nvic and enable isr at the nvic
    UARTIntRegister(UART0_BASE, uart_isr_private);
-   //enable isr at the nvic
-   //IntEnable(INT_UART0);
+
+   // Enable the UART0 interrupt
+   IntEnable(INT_UART0);
 }
 
 void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
-   uart_vars.txCb = txCb;
-   uart_vars.rxCb = rxCb;
+    uart_vars.txCb = txCb;
+    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
-	UARTIntEnable(UART0_BASE, UART_INT_RX |UART_INT_TX);
+void uart_enableInterrupts(){
+    UARTIntEnable(UART0_BASE, UART_INT_RX | UART_INT_TX);
 }
 
-void    uart_disableInterrupts(){
-  UARTIntDisable(UART0_BASE, UART_INT_RX|UART_INT_TX);
+void uart_disableInterrupts(){
+    UARTIntDisable(UART0_BASE, UART_INT_RX | UART_INT_TX);
 }
 
-void    uart_clearRxInterrupts(){
-  UARTIntClear(UART0_BASE, UART_INT_RX);
+void uart_clearRxInterrupts(){
+    UARTIntClear(UART0_BASE, UART_INT_RX);
 }
 
-void    uart_clearTxInterrupts(){
-  UARTIntClear(UART0_BASE, UART_INT_TX);
+void uart_clearTxInterrupts(){
+    UARTIntClear(UART0_BASE, UART_INT_TX);
 }
 
 void  uart_writeByte(uint8_t byteToWrite){
-	//UARTCharPut(UART0_BASE, byteToWrite);
-	UARTCharPutNonBlocking(UART0_BASE, byteToWrite);
-   //UARTIntEnable(UART0_BASE, UART_INT_TX);
+	UARTCharPut(UART0_BASE, byteToWrite);
 }
 
 uint8_t uart_readByte(){
 	 int32_t i32Char;
-     i32Char = UARTCharGetNonBlocking(UART0_BASE);
-     //i32Char = UARTCharGet(UART0_BASE);
+     i32Char = UARTCharGet(UART0_BASE);
 	 return (uint8_t)(i32Char & 0xFF);
 }
 
 //=========================== interrupt handlers ==============================
 
-
-void uart_isr_private(void){
+static void uart_isr_private(void){
 	uint32_t reg;
 	debugpins_isr_set();
 
-	//read source
+	// Read interrupt source
 	reg = UARTIntStatus(UART0_BASE, true);
-	//clear uart nvic interrupt
+
+	// Clear UART interrupt in the NVIC
 	IntPendClear(INT_UART0);
-	//tx isr
+
+	// Process TX interrupt
 	if(reg & UART_INT_TX){
 	     uart_tx_isr();
-	 	 //UARTIntDisable(UART0_BASE, UART_INT_TX);
 	}
-	//rx isr
+
+	// Process RX interrupt
 	if(reg & (UART_INT_RX )) {
 		uart_rx_isr();
 	}
+
 	debugpins_isr_clr();
 }
 
 kick_scheduler_t uart_tx_isr() {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
-   uart_vars.txCb();
+   if (uart_vars.txCb != NULL) {
+       uart_vars.txCb();
+   }
    return DO_NOT_KICK_SCHEDULER;
 }
 
 kick_scheduler_t uart_rx_isr() {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
-   uart_vars.rxCb();
+   if (uart_vars.txCb != NULL) {
+       uart_vars.rxCb();
+   }
    return DO_NOT_KICK_SCHEDULER;
 }


### PR DESCRIPTION
The pull request contains the following:
a) Added code to initialize and select the internal and external antennas via GPIOs
b) Added code to initilize the clocks appropriately (System = 32 MHz, Peripherals = 16 MHz)
c) Added code to initialize the appropriate sleep mode, right now it only goes to PM0 (WFI)
d) Added code to initialize the GPIOs for low power consumptions
e) Added code to initialize the peripherals according to the sleep mode
f) Fixed a bug in the radio that caused to read two more bytes from the receive FIFO
g) Removed a comment from the startup code to ensure that it works with the J-Link
h) Fixed the UART driver to ensure that it is configured appropriately and remove a bug related to the interrupts.
All the fixes have been tested and seem to be working fine.
