### PR TITLE
FW-230. Fix.

### DIFF
--- a/firmware/openos/projects/python/SConscript.env
+++ b/firmware/openos/projects/python/SConscript.env
@@ -47,7 +47,7 @@ if os.name!='nt':
 if not isCrossBuild:
     pythonInc = distutils.sysconfig.get_python_inc()
     pythonLib = distutils.sysconfig.PREFIX+"/lib"
-    if not sys.platform.startwith('darwin'):
+    if not sys.platform.startswith('darwin'):
         pythonLib+="s"
     
 # update C include path


### PR DESCRIPTION
Fixed last warning for letting OpenWSN run on MAC OS.
