### PR TITLE
Added the README.md file in the CC2538 board folder

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/README.md
+++ b/firmware/openos/bsp/boards/cc2538/README.md
@@ -1,0 +1,7 @@
+The OpenWSN BSP (Board Support Package) for the CC2538 platform is based on the
+CC2538 Foundation Firmware provided by Texas Instruments (available at:
+http://www.ti.com/tool/cc2538-sw). The current version of the CC2538 Foundation
+Firmware is Rev. A which dates from May 6, 2013. Information regarding the
+CC2538 Foundation Firmware can be found in the CC2538 Peripheral Driver Library
+User's Guide (available at: http://www.ti.com/lit/pdf/swru325) which also
+dates from May 6, 2013.


### PR DESCRIPTION
[FW-243] I have added the README.md file in the CC2538 folder to indicate that we are using the CC2538 Foundation Firmware provided by Texas Instruments.
