### PR TITLE
FW-256. Flow flow label not relayed during multi-hop upstream transmission.

### DIFF
--- a/firmware/openos/openwsn/03a-IPHC/iphc.c
+++ b/firmware/openos/openwsn/03a-IPHC/iphc.c
@@ -108,7 +108,7 @@ owerror_t iphc_sendFromForwarding(
         if (fw_SendOrfw_Rcv==PCKTFORWARD){
             sam = IPHC_SAM_64B;    //case forwarding a packet
             p_src = &temp_src_mac64b;
-            //poipoi xv forcing elided addresses on src routing, this needs to be fixed so any type of address should be supported supported.
+            //poipoi xv forcing elided addresses on src routing, this needs to be fixed so any type of address should be supported.
         } else if (fw_SendOrfw_Rcv==PCKTSEND){
             sam = IPHC_SAM_ELIDED;
             p_src = NULL;
@@ -164,8 +164,8 @@ owerror_t iphc_sendFromForwarding(
    //then regular header
 
 #ifdef FLOW_LABEL_RPL_DOMAIN
-   if(fw_SendOrfw_Rcv==PCKTSEND  && packetfunctions_isBroadcastMulticast(&(msg->l3_destinationAdd))==FALSE)   {
-	   //only for upstream traffic
+   if(ipv6_header->next_header!=IANA_IPv6ROUTE  && packetfunctions_isBroadcastMulticast(&(msg->l3_destinationAdd))==FALSE)   {
+	   //only for upstream traffic and not DIOs
 	   tf=IPHC_TF_3B;
    }else {
 	   tf=IPHC_TF_ELIDED;
@@ -780,7 +780,7 @@ void iphc_retrieveIPv6HopByHopHeader(
       rpl_option_ht*         rpl_option
    ){
    uint8_t temp_8b;
-   
+#ifndef FLOW_LABEL_RPL_DOMAIN
    // initialize the header length (will increment at each field)
    hopbyhop_header->headerlen     = 0;
    
@@ -844,4 +844,5 @@ void iphc_retrieveIPv6HopByHopHeader(
          );
       }
    }
+#endif
 }

--- a/firmware/openos/openwsn/03b-IPv6/forwarding.c
+++ b/firmware/openos/openwsn/03b-IPv6/forwarding.c
@@ -275,7 +275,8 @@ void forwarding_receive(
 
          forwarding_createRplOption(rpl_option, rpl_option->flags);
          #ifdef FLOW_LABEL_RPL_DOMAIN
-             forwarding_createFlowLabel(&(ipv6_header->flow_label),flags);
+         // do not recreate flow label, relay the same but adding current flags
+         //forwarding_createFlowLabel(&(ipv6_header->flow_label),flags);
          #endif
          // resend as if from upper layer
          if (
@@ -284,7 +285,7 @@ void forwarding_receive(
                   ipv6_header,
                   rpl_option,
                   &(ipv6_header->flow_label),
-                  PCKTFORWARD
+                  PCKTFORWARD 
                )==E_FAIL
             ) {
             openqueue_freePacketBuffer(msg);

--- a/firmware/openos/openwsn/03b-IPv6/forwarding.h
+++ b/firmware/openos/openwsn/03b-IPv6/forwarding.h
@@ -15,8 +15,8 @@
 #define RPL_HOPBYHOP_HEADER_OPTION_TYPE  0x63
 
 enum {
-   PCKTFORWARD     = 1,
-   PCKTSEND        = 2,
+   PCKTFORWARD     = 1, // used by the node to indicate is forwarding a packet  -- either upstream or downstream
+   PCKTSEND        = 2, // used by the node to indicate is sending a packet
 };
 
 enum {

--- a/firmware/openos/openwsn/openwsn.h
+++ b/firmware/openos/openwsn/openwsn.h
@@ -61,7 +61,7 @@ enum {
    IANA_IPv6HOPOPT                     = 0x00,
    IANA_TCP                            = 0x06,
    IANA_UDP                            = 0x11,
-   IANA_IPv6ROUTE                      = 0x2b,
+   IANA_IPv6ROUTE                      = 0x2b,//used for source routing
    IANA_ICMPv6                         = 0x3a,
    IANA_ICMPv6_ECHO_REQUEST            =  128,
    IANA_ICMPv6_ECHO_REPLY              =  129,


### PR DESCRIPTION
Problem was that FORWARDING mode is applied to upstream forwarding and downstream forwarding, IPHC was only considering FLOW_LABEL as 3B when Packet was being sent by the node, not when it was forwarded. The workaround had been to look at the NH and see if it is the IANA_IPv6ROUTE which means downstream routing and then use only TF ELIDED, otherwise use the 3B TF.
