### PR TITLE
FW-258. Fix.

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/uart.c
+++ b/firmware/openos/bsp/boards/cc2538/uart.c
@@ -42,9 +42,16 @@ static void uart_isr_private(void);
 //=========================== public ==========================================
 
 void uart_init() {
+   register uint32_t i;
+   
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
-
+   
+   // wait some time before initializing UART, since don't want the
+   // OpenMoteCC2538 to start generating data before the FTDI chip on the
+   // OpenBase or XBee Explorer has fully initialized
+   for(i=0;i<320000;i++);
+   
    // Disable UART function
    UARTDisable(UART0_BASE);
 


### PR DESCRIPTION
Adding delay before initializing UART, per Pere's suggestion.
