### PR TITLE
FW-262. OpenMoteCC2538 leds.

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/board.c
+++ b/firmware/openos/bsp/boards/cc2538/board.c
@@ -72,9 +72,6 @@ void board_init() {
    radiotimer_init();
    uart_init();
    radio_init();
-#ifndef PLUGFEST
-   leds_debug_on();
-#endif
 }
 
 /**

--- a/firmware/openos/bsp/boards/cc2538/leds.c
+++ b/firmware/openos/bsp/boards/cc2538/leds.c
@@ -63,7 +63,6 @@ uint8_t leds_error_isOn() {
 	  return (uint8_t)(ui32Toggle & BSP_LED_1)>>0;
 }
 
-#ifdef PLUGFEST
 // orange
 void    leds_sync_on() {
 	bspLedSet(BSP_LED_2);
@@ -93,38 +92,6 @@ uint8_t leds_radio_isOn() {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
 	return (uint8_t)(ui32Toggle & BSP_LED_4)>>2;
 }
-
-#else
-// orange
-void    leds_radio_on() {
-	bspLedSet(BSP_LED_2);
-}
-void    leds_radio_off() {
-	bspLedClear(BSP_LED_2);
-}
-void    leds_radio_toggle() {
-	bspLedToggle(BSP_LED_2);
-}
-uint8_t leds_radio_isOn() {
-	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
-    return (uint8_t)(ui32Toggle & BSP_LED_2)>>1;
-}
-
-// green
-void    leds_sync_on() {
-	bspLedSet(BSP_LED_4);
-}
-void    leds_sync_off() {
-	bspLedClear(BSP_LED_4);
-}
-void    leds_sync_toggle() {
-	bspLedToggle(BSP_LED_4);
-}
-uint8_t leds_sync_isOn() {
-	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
-	return (uint8_t)(ui32Toggle & BSP_LED_4)>>2;
-}
-#endif
 
 // yellow
 void    leds_debug_on() {

--- a/firmware/openos/openwsn/02b-MAChigh/sixtop.c
+++ b/firmware/openos/openwsn/02b-MAChigh/sixtop.c
@@ -783,9 +783,7 @@ void sixtop_six2six_sendDone(OpenQueueEntry_t* msg, owerror_t error){
                                 &(msg->l2_nextORpreviousHop));
       }
       sixtop_vars.six2six_state = SIX_IDLE;
-#ifndef PLUGFEST
       leds_debug_off();
-#endif
       break;
    default:
       //log error
@@ -1075,9 +1073,7 @@ void sixtop_notifyReceiveLinkResponse(
       // link request success,inform uplayer
       }
    }
-#ifndef PLUGFEST
    leds_debug_off();
-#endif
    sixtop_vars.six2six_state = SIX_IDLE;
   
    opentimers_stop(sixtop_vars.timeoutTimerId);
@@ -1094,17 +1090,13 @@ void sixtop_notifyReceiveRemoveLinkRequest(
    frameID = schedule_ie->frameID;
    cellList = schedule_ie->cellList;
    
-#ifndef PLUGFEST
    leds_debug_on();
-#endif
   
    sixtop_removeCellsByState(frameID,numOfCells,cellList,addr);
   
    sixtop_vars.six2six_state = SIX_IDLE;
 
-#ifndef PLUGFEST
    leds_debug_off();
-#endif
 }
 
 //======= helper functions


### PR DESCRIPTION
Changed behavior of leds for OpenMoteCC2538: green -> radio, orange -> sync (compliance with TelosB, with orange led substituting the TelosB blue one). Led yellow (debug) is turned off and disabled in 6top.
