### PR TITLE
FW-258. Fix.

### DIFF
--- a/firmware/openos/bsp/boards/cc2538/uart.c
+++ b/firmware/openos/bsp/boards/cc2538/uart.c
@@ -41,16 +41,9 @@ static void uart_isr_private(void);
 
 //=========================== public ==========================================
 
-void uart_init() {
-   register uint32_t i;
-   
+void uart_init() { 
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
-   
-   // wait some time before initializing UART, since don't want the
-   // OpenMoteCC2538 to start generating data before the FTDI chip on the
-   // OpenBase or XBee Explorer has fully initialized
-   for(i=0;i<320000;i++);
    
    // Disable UART function
    UARTDisable(UART0_BASE);


### PR DESCRIPTION
(Finally) Fixed FW-258.
a) Removed the initialization delay of the UART peripheral since it is no longer required.
b) The UART peripheral of the CC2538 has a shadow register that needs to be emptied by a timeout interrupt, otherwise the last byte does not get processed until a new byte arrives. This affects the communication with OpenVisualizer since it relies on communicating full HDLC frames.
