### PR TITLE
Update OpenMote-CC2538 startup script

### DIFF
--- a/bsp/boards/OpenMote-CC2538/startup_gcc.c
+++ b/bsp/boards/OpenMote-CC2538/startup_gcc.c
@@ -68,7 +68,7 @@ void IntDefaultHandler(void);
 // Reserve space for the system stack.
 //
 //*****************************************************************************
-static uint32_t pui32Stack[128];
+static uint32_t pui32Stack[512];
 
 //*****************************************************************************
 //


### PR DESCRIPTION
Updated the OpenMote-CC2538 startup script to increase stack size from 128 bytes to 512 bytes.
