### PR TITLE
Fix for FW-316.

### DIFF
--- a/bsp/boards/OpenMote-CC2538/cc2538.lds
+++ b/bsp/boards/OpenMote-CC2538/cc2538.lds
@@ -34,12 +34,13 @@ SECTIONS
     } > FLASH=0
 
     .data :
+    AT (ADDR (.text) + SIZEOF (.text))
     {
         _data = .;
         *(vtable)
         *(.data*)
         _edata = .;
-    } > SRAM AT > FLASH
+    } > SRAM
 
     .ARM.exidx :
     {


### PR DESCRIPTION
Fixed the OpenMote-CC2538 linker script according to FW-316. The previous script worked fine but seemed to fail under certain circumstances. The current script is supposed to be more restrictive and, thus, work more reliably.
