### PR TITLE
FW-371. Implement functions to read and write RAM on CC2420.

### DIFF
--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -66,11 +66,11 @@ void radio_spiReadReg(uint8_t reg, cc2420_status_t* statusRead, uint8_t* regValu
    *(regValueRead+1)    = spi_rx_buffer[1];
 }
 
-void radio_spiWriteTxFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len) {
+void radio_spiWriteFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len, uint8_t addr) {
    uint8_t              spi_tx_buffer[2];
    
    // step 1. send SPI address and length byte
-   spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | CC2420_TXFIFO_ADDR);
+   spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | addr);
    spi_tx_buffer[1]     = len;
    
    spi_txrx(

--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -177,7 +177,7 @@ void radio_spiReadRam(uint16_t addr,
 
 // step 1. send SPI address
    spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
-   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_READ;
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_RAM_READ;
  
    // 2 first bytes
    spi_txrx(
@@ -212,7 +212,7 @@ void radio_spiWriteRam(uint16_t addr,
 
 // step 1. send SPI address
    spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
-   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_WRITE;
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_RAM_WRITE;
    
    spi_txrx(
       spi_tx_buffer,              // bufTx

--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -167,4 +167,72 @@ void radio_spiReadRxFifo(cc2420_status_t* statusRead,
    }
 }
 
+void radio_spiReadRam(uint16_t addr,
+                         cc2420_status_t* statusRead,
+                         uint8_t*         pBufRead,
+                         uint8_t          len) {
+
+   uint8_t spi_tx_buffer[2];
+   uint8_t spi_rx_buffer[3];
+
+// step 1. send SPI address
+   spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_READ;
+ 
+   // 2 first bytes
+   spi_txrx(
+      spi_tx_buffer,              // bufTx
+      2,                          // lenbufTx
+      SPI_BUFFER,                 // returnType
+      spi_rx_buffer,              // bufRx
+      sizeof(spi_rx_buffer),      // maxLenBufRx
+      SPI_FIRST,                  // isFirst
+      SPI_NOTLAST                 // isLast
+   );
+   
+   *statusRead          = *(cc2420_status_t*)&spi_rx_buffer[0];
+   
+   //read the actual bytes in RAM
+   spi_txrx(
+      spi_tx_buffer,           // bufTx
+      len,                     // lenbufTx   // we will transfer len-2 garbage bytes, while receiving. does it matter?
+      SPI_BUFFER,              // returnType
+      pBufRead,                // bufRx
+      len,                     // maxLenBufRx
+      SPI_NOTFIRST,            // isFirst
+      SPI_LAST                 // isLast
+   );
+}
+
+void radio_spiWriteRam(uint16_t addr,
+                        cc2420_status_t* statusRead,
+                        uint8_t* bufToWrite,
+                        uint8_t len) {
+   uint8_t spi_tx_buffer[2];
+
+// step 1. send SPI address
+   spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_WRITE;
+   
+   spi_txrx(
+      spi_tx_buffer,              // bufTx
+      sizeof(spi_tx_buffer),      // lenbufTx
+      SPI_FIRSTBYTE,              // returnType
+      (uint8_t*)statusRead,       // bufRx
+      1,                          // maxLenBufRx
+      SPI_FIRST,                  // isFirst
+      SPI_NOTLAST                 // isLast
+   );
+   
+   // step 2. send payload
+   spi_txrx(
+      bufToWrite,                 // bufTx
+      len,                        // lenbufTx
+      SPI_LASTBYTE,               // returnType
+      (uint8_t*)statusRead,       // bufRx
+      1,                          // maxLenBufRx
+      SPI_NOTFIRST,               // isFirst
+      SPI_LAST                    // isLast
+   );
+}
 

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -404,6 +404,23 @@ typedef struct {
 /// [R/W] Receiver FIFO Byte Register
 #define CC2420_RXFIFO_ADDR        0x3f
 
+//=========================== RAM addresses ===================================
+
+/// CC2420 RAM Memory Space
+#define CC2420_RAM_TXFIFO_ADDR      0x000     
+#define CC2420_RAM_RXFIFO_ADDR      0x080
+#define CC2420_RAM_KEY0_ADDR        0x100
+#define CC2420_RAM_RXNONCE_ADDR     0x110    // RX nonce for authentication
+#define CC2420_RAM_RXCTR_ADDR       0x110    // RX counter for decryption
+#define CC2420_RAM_SABUF_ADDR       0x120    // stand-alone encryption buffer
+#define CC2420_RAM_KEY1_ADDR        0x130
+#define CC2420_RAM_TXNONCE_ADDR     0x140    // TX nonce for authentication
+#define CC2420_RAM_TXCTR_ADDR       0x140    // TX counter for encryption
+#define CC2420_RAM_CBCSTATE_ADDR    0x150
+#define CC2420_RAM_IEEEADR_ADDR     0x160
+#define CC2420_RAM_PANID_ADDR       0x168
+#define CC2420_RAM_SHORTADR_ADDR    0x16A
+
 //=========================== prototypes ======================================
 
 void radio_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -429,7 +429,7 @@ typedef struct {
 void radio_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);
 void radio_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t regValueToWrite);
 void radio_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
-void radio_spiWriteTxFifo(                cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite);
+void radio_spiWriteFifo(                  cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite, uint8_t addr);
 void radio_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
 void radio_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
 void radio_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -431,5 +431,7 @@ void radio_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t 
 void radio_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
 void radio_spiWriteTxFifo(                cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite);
 void radio_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
+void radio_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
+void radio_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);
 
 #endif

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -12,6 +12,9 @@
 #define CC2420_FLAG_READ          0x40
 #define CC2420_FLAG_WRITE         0x00
 
+#define CC2420_FLAG_RAM_READ      0x20
+#define CC2420_FLAG_RAM_WRITE     0x00
+
 #define CC2420_FLAG_RAM           0x80
 #define CC2420_FLAG_REG           0x00
 

--- a/bsp/chips/cc2420/radio.c
+++ b/bsp/chips/cc2420/radio.c
@@ -203,7 +203,7 @@ void radio_loadPacket(uint8_t* packet, uint8_t len) {
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
    
    radio_spiStrobe(CC2420_SFLUSHTX, &radio_vars.radioStatusByte);
-   radio_spiWriteTxFifo(&radio_vars.radioStatusByte, packet, len);
+   radio_spiWriteFifo(&radio_vars.radioStatusByte, packet, len, CC2420_TXFIFO_ADDR);
    
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;


### PR DESCRIPTION
This pull request implements functions that read and write CC2420 RAM over SPI. 
Additionally, it modifies ```radio_spiWriteTxFifo()``` in order to generalize it and allow write access to RX FIFO, by accepting the register address argument. Write access to RX FIFO is needed for in-line decryption of CC2420.