### PR TITLE
FW-372. Crypto hardware acceleration for CC2420 boards.

### DIFF
--- a/bsp/boards/telosb/SConscript
+++ b/bsp/boards/telosb/SConscript
@@ -29,6 +29,12 @@ source = [
     'board_crypto_engine.c',
 ]
 
+localEnv.Append(
+        CPPPATH =  [
+            os.path.join('#','bsp','chips','cc2420'),
+        ],
+)
+
 board  = localEnv.Object(source=source) + cc2420
 
 Return('board')

--- a/bsp/boards/telosb/SConscript
+++ b/bsp/boards/telosb/SConscript
@@ -26,6 +26,7 @@ source = [
     'radiotimer.c',
     'spi.c',
     'uart.c',
+    'board_crypto_engine.c',
 ]
 
 board  = localEnv.Object(source=source) + cc2420

--- a/bsp/boards/telosb/board_crypto_engine.c
+++ b/bsp/boards/telosb/board_crypto_engine.c
@@ -48,7 +48,7 @@ return E_SUCCESS;
 /*---------------------------------------------------------------------------*/
 const struct crypto_engine board_crypto_engine = {
    cc2420_crypto_ccms_enc,
-   aes_ccms_dec,
+   cc2420_crypto_ccms_dec,
    aes_cbc_enc_raw,
    aes_ctr_enc_raw,
    cc2420_crypto_aes_ecb_enc,      // AES stand-alone encryption

--- a/bsp/boards/telosb/board_crypto_engine.c
+++ b/bsp/boards/telosb/board_crypto_engine.c
@@ -17,34 +17,6 @@ static owerror_t init(void) {
    return E_SUCCESS;
 }
 
-static owerror_t aes_ccms_enc_cc2420(uint8_t* a,
-         uint8_t len_a,
-         uint8_t* m,
-         uint8_t* len_m,
-         uint8_t* nonce,
-         uint8_t l,
-         uint8_t key[16],
-         uint8_t len_mac) {
-
-   return E_SUCCESS;
-}
-
-static owerror_t aes_ccms_dec_cc2420(uint8_t* a,
-         uint8_t len_a,
-         uint8_t* m,
-         uint8_t* len_m,
-         uint8_t* nonce,
-         uint8_t l,
-         uint8_t key[16],
-         uint8_t len_mac) {
-
-   return E_FAIL;
-}
-
-static owerror_t aes_ecb_enc_cc2420(uint8_t* buffer, uint8_t* key) {
-
-return E_SUCCESS;
-}
 /*---------------------------------------------------------------------------*/
 const struct crypto_engine board_crypto_engine = {
    cc2420_crypto_ccms_enc,

--- a/bsp/boards/telosb/board_crypto_engine.c
+++ b/bsp/boards/telosb/board_crypto_engine.c
@@ -9,6 +9,7 @@
 #include "aes_ctr.h"
 #include "aes_cbc.h"
 #include "aes_ccms.h"
+#include "cc2420_crypto.h"
 
 static owerror_t init(void) {
    return E_SUCCESS;
@@ -44,11 +45,11 @@ return E_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
 const struct crypto_engine board_crypto_engine = {
-   aes_ccms_enc,
+   cc2420_crypto_ccms_enc,
    aes_ccms_dec,
    aes_cbc_enc_raw,
    aes_ctr_enc_raw,
-   aes_ecb_enc,      // AES stand-alone encryption
+   cc2420_crypto_aes_ecb_enc,      // AES stand-alone encryption
    init,
 };
 /*---------------------------------------------------------------------------*/

--- a/bsp/boards/telosb/board_crypto_engine.c
+++ b/bsp/boards/telosb/board_crypto_engine.c
@@ -10,8 +10,10 @@
 #include "aes_cbc.h"
 #include "aes_ccms.h"
 #include "cc2420_crypto.h"
+#include "radio.h"
 
 static owerror_t init(void) {
+   radio_rfOn();  // turn the crystal oscillator on in order to access CC2420 RAM
    return E_SUCCESS;
 }
 

--- a/bsp/boards/telosb/board_crypto_engine.c
+++ b/bsp/boards/telosb/board_crypto_engine.c
@@ -1,0 +1,55 @@
+/**
+\brief Crypto engine implementation for TelosB (CC2420)
+  
+\author Malisa Vucinic <malishav@gmail.com>, March 2015.
+*/
+#include <stdint.h>
+#include "board_crypto_engine.h"
+#include "aes_ecb.h"
+#include "aes_ctr.h"
+#include "aes_cbc.h"
+#include "aes_ccms.h"
+
+static owerror_t init(void) {
+   return E_SUCCESS;
+}
+
+static owerror_t aes_ccms_enc_cc2420(uint8_t* a,
+         uint8_t len_a,
+         uint8_t* m,
+         uint8_t* len_m,
+         uint8_t* nonce,
+         uint8_t l,
+         uint8_t key[16],
+         uint8_t len_mac) {
+
+   return E_SUCCESS;
+}
+
+static owerror_t aes_ccms_dec_cc2420(uint8_t* a,
+         uint8_t len_a,
+         uint8_t* m,
+         uint8_t* len_m,
+         uint8_t* nonce,
+         uint8_t l,
+         uint8_t key[16],
+         uint8_t len_mac) {
+
+   return E_FAIL;
+}
+
+static owerror_t aes_ecb_enc_cc2420(uint8_t* buffer, uint8_t* key) {
+
+return E_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+const struct crypto_engine board_crypto_engine = {
+   aes_ccms_enc,
+   aes_ccms_dec,
+   aes_cbc_enc_raw,
+   aes_ctr_enc_raw,
+   aes_ecb_enc,      // AES stand-alone encryption
+   init,
+};
+/*---------------------------------------------------------------------------*/
+

--- a/bsp/boards/telosb/board_crypto_engine.h
+++ b/bsp/boards/telosb/board_crypto_engine.h
@@ -1,0 +1,24 @@
+/**
+\brief TelosB crypto engine implementation header
+
+\author Malisa Vucinic <malishav@gmail.com>, March 2015.
+*/
+#ifndef __BOARD_CRYPTO_ENGINE_H__
+#define __BOARD_CRYPTO_ENGINE_H__
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#include "crypto_engine.h"
+
+//=========================== module variables ================================
+
+extern const struct crypto_engine board_crypto_engine;   
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* __BOARD_CRYPTO_ENGINE_H__ */
+

--- a/bsp/chips/cc2420/SConscript
+++ b/bsp/chips/cc2420/SConscript
@@ -7,7 +7,7 @@ Import('env')
 
 localEnv = env.Clone()
 
-source = ['radio.c', 'cc2420.c']
+source = ['radio.c', 'cc2420.c', 'cc2420_crypto.c']
 cc2420 = localEnv.Object(
    source=source,
 )

--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -66,11 +66,11 @@ void radio_spiReadReg(uint8_t reg, cc2420_status_t* statusRead, uint8_t* regValu
    *(regValueRead+1)    = spi_rx_buffer[1];
 }
 
-void radio_spiWriteTxFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len) {
+void radio_spiWriteFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len, uint8_t addr) {
    uint8_t              spi_tx_buffer[2];
    
    // step 1. send SPI address and length byte
-   spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | CC2420_TXFIFO_ADDR);
+   spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | addr);
    spi_tx_buffer[1]     = len;
    
    spi_txrx(

--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -177,7 +177,7 @@ void radio_spiReadRam(uint16_t addr,
 
 // step 1. send SPI address
    spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
-   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_READ;
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_RAM_READ;
  
    // 2 first bytes
    spi_txrx(
@@ -212,7 +212,7 @@ void radio_spiWriteRam(uint16_t addr,
 
 // step 1. send SPI address
    spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
-   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_WRITE;
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_RAM_WRITE;
    
    spi_txrx(
       spi_tx_buffer,              // bufTx

--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -167,4 +167,72 @@ void radio_spiReadRxFifo(cc2420_status_t* statusRead,
    }
 }
 
+void radio_spiReadRam(uint16_t addr,
+                         cc2420_status_t* statusRead,
+                         uint8_t*         pBufRead,
+                         uint8_t          len) {
+
+   uint8_t spi_tx_buffer[2];
+   uint8_t spi_rx_buffer[3];
+
+// step 1. send SPI address
+   spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_READ;
+ 
+   // 2 first bytes
+   spi_txrx(
+      spi_tx_buffer,              // bufTx
+      2,                          // lenbufTx
+      SPI_BUFFER,                 // returnType
+      spi_rx_buffer,              // bufRx
+      sizeof(spi_rx_buffer),      // maxLenBufRx
+      SPI_FIRST,                  // isFirst
+      SPI_NOTLAST                 // isLast
+   );
+   
+   *statusRead          = *(cc2420_status_t*)&spi_rx_buffer[0];
+   
+   //read the actual bytes in RAM
+   spi_txrx(
+      spi_tx_buffer,           // bufTx
+      len,                     // lenbufTx   // we will transfer len-2 garbage bytes, while receiving. does it matter?
+      SPI_BUFFER,              // returnType
+      pBufRead,                // bufRx
+      len,                     // maxLenBufRx
+      SPI_NOTFIRST,            // isFirst
+      SPI_LAST                 // isLast
+   );
+}
+
+void radio_spiWriteRam(uint16_t addr,
+                        cc2420_status_t* statusRead,
+                        uint8_t* bufToWrite,
+                        uint8_t len) {
+   uint8_t spi_tx_buffer[2];
+
+// step 1. send SPI address
+   spi_tx_buffer[0] = (CC2420_FLAG_RAM | (addr & 0x7F));
+   spi_tx_buffer[1] = ((addr >> 1) & 0xC0) | CC2420_FLAG_WRITE;
+   
+   spi_txrx(
+      spi_tx_buffer,              // bufTx
+      sizeof(spi_tx_buffer),      // lenbufTx
+      SPI_FIRSTBYTE,              // returnType
+      (uint8_t*)statusRead,       // bufRx
+      1,                          // maxLenBufRx
+      SPI_FIRST,                  // isFirst
+      SPI_NOTLAST                 // isLast
+   );
+   
+   // step 2. send payload
+   spi_txrx(
+      bufToWrite,                 // bufTx
+      len,                        // lenbufTx
+      SPI_LASTBYTE,               // returnType
+      (uint8_t*)statusRead,       // bufRx
+      1,                          // maxLenBufRx
+      SPI_NOTFIRST,               // isFirst
+      SPI_LAST                    // isLast
+   );
+}
 

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -404,6 +404,23 @@ typedef struct {
 /// [R/W] Receiver FIFO Byte Register
 #define CC2420_RXFIFO_ADDR        0x3f
 
+//=========================== RAM addresses ===================================
+
+/// CC2420 RAM Memory Space
+#define CC2420_RAM_TXFIFO_ADDR      0x000     
+#define CC2420_RAM_RXFIFO_ADDR      0x080
+#define CC2420_RAM_KEY0_ADDR        0x100
+#define CC2420_RAM_RXNONCE_ADDR     0x110    // RX nonce for authentication
+#define CC2420_RAM_RXCTR_ADDR       0x110    // RX counter for decryption
+#define CC2420_RAM_SABUF_ADDR       0x120    // stand-alone encryption buffer
+#define CC2420_RAM_KEY1_ADDR        0x130
+#define CC2420_RAM_TXNONCE_ADDR     0x140    // TX nonce for authentication
+#define CC2420_RAM_TXCTR_ADDR       0x140    // TX counter for encryption
+#define CC2420_RAM_CBCSTATE_ADDR    0x150
+#define CC2420_RAM_IEEEADR_ADDR     0x160
+#define CC2420_RAM_PANID_ADDR       0x168
+#define CC2420_RAM_SHORTADR_ADDR    0x16A
+
 //=========================== prototypes ======================================
 
 void radio_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -429,7 +429,7 @@ typedef struct {
 void radio_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);
 void radio_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t regValueToWrite);
 void radio_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
-void radio_spiWriteTxFifo(                cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite);
+void radio_spiWriteFifo(                  cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite, uint8_t addr);
 void radio_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
 void radio_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
 void radio_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -431,5 +431,7 @@ void radio_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t 
 void radio_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
 void radio_spiWriteTxFifo(                cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite);
 void radio_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
+void radio_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
+void radio_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);
 
 #endif

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -12,6 +12,9 @@
 #define CC2420_FLAG_READ          0x40
 #define CC2420_FLAG_WRITE         0x00
 
+#define CC2420_FLAG_RAM_READ      0x20
+#define CC2420_FLAG_RAM_WRITE     0x00
+
 #define CC2420_FLAG_RAM           0x80
 #define CC2420_FLAG_REG           0x00
 

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -226,13 +226,12 @@ static void create_cc2420_nonce(uint8_t l,
    // Create nonce
    buffer[0] = 0x00; // set flags to zero including reserved
    buffer[0] |= 0x07 & (l-1); // field L
-   // (len_mac - 2)/2 shifted left 3 times corresponds to (len_mac - 2) << 2
-   buffer[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
-   buffer[0] |= len_a != 0 ? 0x40 : 0; // field Adata
-   memcpy(&buffer[1], nonce154, 13);
+   buffer[0] |= len_a != 0 ? 0x08 : 0; // field Adata in CC2420's nonce (see datasheet)
+   memcpy(&buffer[1], nonce154, 13); 
    if (l == 3) { buffer[13] = 0; }
-   buffer[14] = 0x00;
-   buffer[15] = 0x00; // should this be zero or one?
+   buffer[14] = 0x00; // block counter
+   buffer[15] = 0x01; // block counter
+   reverse(buffer, 16);
 }
 
 static void reverse(uint8_t *start, uint8_t len) {

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -17,14 +17,16 @@
 //=========================== prototypes ======================================
 static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_index);
 
-static owerror_t cc2420_crypto_inline_ccms_enc(uint8_t* a,
-                                 uint8_t len_a,
-                                 uint8_t* m,
-                                 uint8_t* len_m,
-                                 uint8_t* nonce,
-                                 uint8_t l,
-                                 uint8_t key[16],
-                                 uint8_t len_mac);
+static owerror_t cc2420_launch_enc_and_auth(uint8_t len_a,
+                                 uint8_t len_mac,
+                                 uint8_t key_index,
+                                 cc2420_status_t *status);
+
+static void create_cc2420_nonce(uint8_t l, 
+                           uint8_t len_mac,
+                           uint8_t len_a,
+                           uint8_t* nonce154,
+                           uint8_t* buffer);
 
 //=========================== public ==========================================
 
@@ -65,25 +67,80 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
                         uint8_t l,
                         uint8_t key[16],
                         uint8_t len_mac) {
-   // need to separate the calls to mimic CC2420 operation
-   // both encryption and authentication
-   if (len_mac > 0 && *len_m > 0) {
-      return cc2420_crypto_inline_ccms_enc(a,
-                                          len_a,
-                                          m,
-                                          len_m,
-                                          nonce,
-                                          l,
-                                          key,
-                                          len_mac);
-   }
-   // authentication only
-   else if (len_mac > 0 && *len_m == 0) {
+   uint8_t key_index;
+   uint8_t total_message_len;
+   uint8_t buffer[128];
+   uint8_t cc2420_nonce[16];
+   cc2420_status_t status;
+
+   if (!((len_mac == 0) || (len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
       return E_FAIL;
    }
-   //encryption only (insecure)
-   else if (len_mac == 0 && *len_m > 0) {
+
+   // CRC needs to be accounted for in the message len but does not affect encryption
+   total_message_len = len_a + *len_m + len_mac + LENGTH_CRC;
+
+   if (total_message_len > 127) { // CC2420 FIFO size is the limiting factor
       return E_FAIL;
+   }
+
+   // load key
+   if (cc2420_crypto_load_key(key, &key_index) == E_SUCCESS) {
+         
+      // make sure the Additional Data is concatenated with plaintext
+      // add the length byte at the beginning that CC2420 expects
+      memcpy(buffer, &total_message_len, 1);
+      memcpy(&buffer[1], a, len_a);
+      memcpy(&buffer[len_a + 1], m, *len_m);
+      memcpy(&buffer[len_a + *len_m + 1], 0x00, len_mac ); // CC2420 expects MIC and CRC bytes allocated 
+
+      // Write the message to the TX FIFO for encryption and/or authentication
+      radio_spiWriteRam(CC2420_RAM_TXFIFO_ADDR, &status, buffer, 16, total_message_len + 1);
+
+      // Create and write the nonce to the CC2420 RAM
+      create_cc2420_nonce(l, len_mac, len_a, nonce, cc2420_nonce);
+      radio_spiWriteRam(CC2420_RAM_TXNONCE_ADDR, &status, cc2420_nonce, 16);
+      
+      // need to separate the calls to mimic CC2420 operation
+      // both encryption and authentication
+      if (len_mac > 0 && *len_m > 0) {
+         cc2420_launch_enc_and_auth(len_a, len_mac, key_index, &status);
+      }
+      // authentication only
+      else if (len_mac > 0 && *len_m == 0) {
+         return E_FAIL;
+      }
+      //encryption only (insecure)
+      else if (len_mac == 0 && *len_m > 0) {
+         return E_FAIL;
+      }
+   
+      // Once command is launched, busy wait for the crypt block to finish
+      while (status.enc_busy == 1) {
+         radio_spiStrobe(CC2420_SNOP, &status);
+      }
+
+      // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
+      radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR,
+                         &status,
+                         buffer,
+                         total_message_len + 1); // plus one for the length byte
+
+      if (buffer[0] != total_message_len) {
+         return E_FAIL;
+      }
+
+      // Write ciphertext to vector m[]
+      radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + len_a, // one for the length byte
+                         &status,
+                         m,
+                         *len_m + len_mac); // ciphertext plus MIC
+
+      *len_m += len_mac;
+
+      // flush TX Fifo ???
+      radio_spiStrobe(CC2420_SFLUSHTX, &status);
+      radio_spiStrobe(CC2420_SFLUSHTX, &status);
    }
    return E_FAIL;
 }
@@ -103,129 +160,63 @@ static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_
    return E_SUCCESS;
 }
 
-// private function supporting only authentication + encryption 
-static owerror_t cc2420_crypto_inline_ccms_enc(uint8_t* a,
-                                 uint8_t len_a,
-                                 uint8_t* m,
-                                 uint8_t* len_m,
-                                 uint8_t* nonce,
-                                 uint8_t l,
-                                 uint8_t key[16],
-                                 uint8_t len_mac) {
-   uint8_t key_index;
-   uint8_t buffer[128];
-   uint8_t cc2420_nonce[16];
-   uint8_t total_message_len;
+// private function launching both authentication + encryption 
+static owerror_t cc2420_launch_enc_and_auth(uint8_t len_a,
+                                 uint8_t len_mac,
+                                 uint8_t key_index,
+                                 cc2420_status_t *status) {
    cc2420_SECCTRL0_reg_t cc2420_SECCTRL0_reg;
    cc2420_SECCTRL1_reg_t cc2420_SECCTRL1_reg;
-   cc2420_status_t status;
+
+   //configure SECCTRL0 and SECTRL1
+   // key selection for TX
+   // write nonce for TX
+   // SECCTRL0.SEC_MODE = CCM
+
+   cc2420_SECCTRL0_reg.SEC_MODE = CC2420_SECCTRL0_SEC_MODE_CCM;
+   cc2420_SECCTRL0_reg.SEC_M = (len_mac - 2) >> 1; // (M-2)/2
+   cc2420_SECCTRL0_reg.SEC_RXKEYSEL = 0;
+   cc2420_SECCTRL0_reg.SEC_TXKEYSEL = key_index;
+   cc2420_SECCTRL0_reg.SEC_SAKEYSEL = 0;
+   cc2420_SECCTRL0_reg.SEC_CBC_HEAD = 1; // use len_a as first byte of authenticated data
+   cc2420_SECCTRL0_reg.RXFIFO_PROTECTION = 0;
+   cc2420_SECCTRL0_reg.reserved_w0 = 0;
+
+   /// Security Control Register 1
+   cc2420_SECCTRL1_reg.SEC_RXL = 0;
+   cc2420_SECCTRL1_reg.reserved_1_w0 = 0;
+   cc2420_SECCTRL1_reg.SEC_TXL = len_a; // number of bytes until first encrypted byte
+   cc2420_SECCTRL1_reg.reserved_2_w0 = 0;
 
 
-   if (!((len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
-      return E_FAIL;
-   }
-
-   if (*len_m > 125 || *len_m == 0) {
-      return E_FAIL;
-   }
-
-   // CRC needs to be accounted for in the message len but does not affect encryption
-   total_message_len = len_a + *len_m + len_mac + LENGTH_CRC;
-
-   if (total_message_len > 127) {
-      return E_FAIL;
-   }
-
-
-   // load key
-   if (cc2420_crypto_load_key(key, &key_index) == E_SUCCESS) {
-               // make sure the Additional Data is concatenated with plaintext
-               memcpy(buffer, a, len_a);
-               memcpy(&buffer[len_a], m, *len_m);
-               memcpy(&buffer[len_a + *len_m], 0x00, len_mac ); // CC2420 expects MIC and CRC bytes allocated 
-
-               // load in tx buffer the concatenated message in order to use inline encryption mode
-               radio_spiWriteTxFifo(&status, buffer, total_message_len);
-
-
-               //configure SECCTRL0 and SECTRL1
-               // key selection for TX
-               // write nonce for TX
-               // SECCTRL0.SEC_MODE = CCM
-
-               cc2420_SECCTRL0_reg.SEC_MODE = CC2420_SECCTRL0_SEC_MODE_CCM;
-               cc2420_SECCTRL0_reg.SEC_M = (len_mac - 2) >> 1; // (M-2)/2
-               cc2420_SECCTRL0_reg.SEC_RXKEYSEL = 0;
-               cc2420_SECCTRL0_reg.SEC_TXKEYSEL = key_index;
-               cc2420_SECCTRL0_reg.SEC_SAKEYSEL = 0;
-               cc2420_SECCTRL0_reg.SEC_CBC_HEAD = 1; // use len_a as first byte of authenticated data
-               cc2420_SECCTRL0_reg.RXFIFO_PROTECTION = 0;
-               cc2420_SECCTRL0_reg.reserved_w0 = 0;
-
-               /// Security Control Register 1
-               cc2420_SECCTRL1_reg.SEC_RXL = 0;
-               cc2420_SECCTRL1_reg.reserved_1_w0 = 0;
-               cc2420_SECCTRL1_reg.SEC_TXL = len_a; // number of bytes until first encrypted byte
-               cc2420_SECCTRL1_reg.reserved_2_w0 = 0;
-
-               cc2420_nonce[0] = 0x00; // set flags to zero including reserved
-               cc2420_nonce[0] |= 0x07 & (l-1); // field L
-               // (len_mac - 2)/2 shifted left 3 times corresponds to (len_mac - 2) << 2
-               cc2420_nonce[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
-               cc2420_nonce[0] |= len_a != 0 ? 0x40 : 0; // field Adata
-   
-               memcpy(&cc2420_nonce[1], nonce, 13);
-
-               if (l == 3) {
-                  cc2420_nonce[13] = 0;
-               }
-
-               cc2420_nonce[14] = 0x00;
-               cc2420_nonce[15] = 0x00; // should this be zero or one?
-               
-               // Write the nonce to the CC2420 RAM
-               radio_spiWriteRam(CC2420_RAM_TXNONCE_ADDR, &status, cc2420_nonce, 16);
-
-               // Write to two CC2420 security registers
-               radio_spiWriteReg(CC2420_SECCTRL0_ADDR, 
-                     &status,
+   // Write to two CC2420 security registers
+   radio_spiWriteReg(CC2420_SECCTRL0_ADDR, 
+                     status,
                      *(uint16_t*)&cc2420_SECCTRL0_reg);
                
-               radio_spiWriteReg(CC2420_SECCTRL1_ADDR, 
-                     &status,
+   radio_spiWriteReg(CC2420_SECCTRL1_ADDR, 
+                     status,
                      *(uint16_t*)&cc2420_SECCTRL1_reg);
 
-               // issue STXENC to encrypt but not start the transmission
-               radio_spiStrobe(CC2420_STXENC, &status);
-               while (status.enc_busy == 1) {
-                  radio_spiStrobe(CC2420_SNOP, &status);
-               }
- 
-               // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
-               radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR,
-                         &status,
-                         buffer,
-                         total_message_len + 1); // plus one for the length byte
-
-               if (buffer[0] != total_message_len) {
-                  return E_FAIL;
-               }
-
-               // Write ciphertext to vector m[]
-               radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + len_a, // one for the length byte
-                         &status,
-                         m,
-                         *len_m + len_mac); // ciphertext plus MIC
-
-               *len_m += len_mac;
-
-               // flush TX Fifo ???
-               radio_spiStrobe(CC2420_SFLUSHTX, &status);
-               radio_spiStrobe(CC2420_SFLUSHTX, &status);
-
-               return E_SUCCESS;
-   }
-   return E_FAIL;
+   // issue STXENC to encrypt but not start the transmission
+   radio_spiStrobe(CC2420_STXENC, status);
+   return E_SUCCESS;
 }
 
+static void create_cc2420_nonce(uint8_t l, 
+                           uint8_t len_mac,
+                           uint8_t len_a,
+                           uint8_t* nonce154,
+                           uint8_t* buffer) {
+   // Create nonce
+   buffer[0] = 0x00; // set flags to zero including reserved
+   buffer[0] |= 0x07 & (l-1); // field L
+   // (len_mac - 2)/2 shifted left 3 times corresponds to (len_mac - 2) << 2
+   buffer[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
+   buffer[0] |= len_a != 0 ? 0x40 : 0; // field Adata
+   memcpy(&buffer[1], nonce154, 13);
+   if (l == 3) { buffer[13] = 0; }
+   buffer[14] = 0x00;
+   buffer[15] = 0x00; // should this be zero or one?
+}
 

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -236,7 +236,7 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
       }
 
       // Write ciphertext to vector m[]
-      radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + offset, // one for the length byte
+      radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + len_a, // one for the length byte
                          &status,
                          m,
                          *len_m + len_mac); // ciphertext plus MIC
@@ -292,7 +292,7 @@ static owerror_t cc2420_conf_sec_regs(uint8_t mode,
 
    //configure SECCTRL0 and SECTRL1
    cc2420_SECCTRL0_reg.SEC_MODE = mode;
-   cc2420_SECCTRL0_reg.SEC_M = (len_mac - 2) >> 1; // (M-2)/2
+   cc2420_SECCTRL0_reg.SEC_M = len_mac != 0 ? (len_mac - 2) >> 1 : 0; // (M-2)/2 or 0
 
    switch (enc_flag) {
       case CC2420_SEC_ENC:

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -50,9 +50,10 @@ owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
       
       // launch stand-alone AES encryption
       radio_spiStrobe(CC2420_SAES, &status);
-      while (status.enc_busy == 1) {
+      do {
          radio_spiStrobe(CC2420_SNOP, &status);
       }
+      while (status.enc_busy == 1);
       
       // read the ciphertext and overwrite the original buffer
       radio_spiReadRam(CC2420_RAM_SABUF_ADDR, &status, buffer, 16);
@@ -94,7 +95,7 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
       memcpy(buffer, &total_message_len, 1);
       memcpy(&buffer[1], a, len_a);
       memcpy(&buffer[len_a + 1], m, *len_m);
-      memcpy(&buffer[len_a + *len_m + 1], 0x00, len_mac ); // CC2420 expects MIC and CRC bytes allocated 
+      memset(&buffer[len_a + *len_m + 1], 0x00, len_mac + LENGTH_CRC); // CC2420 expects MIC and CRC bytes allocated 
 
       // Write the message to the TX FIFO for encryption and/or authentication
       radio_spiWriteRam(CC2420_RAM_TXFIFO_ADDR, &status, buffer, 16, total_message_len + 1);
@@ -118,9 +119,10 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
       }
    
       // Once command is launched, busy wait for the crypt block to finish
-      while (status.enc_busy == 1) {
+      do {
          radio_spiStrobe(CC2420_SNOP, &status);
       }
+      while (status.enc_busy == 1);
 
       // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
       radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR,

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -28,6 +28,8 @@ static void create_cc2420_nonce(uint8_t l,
                            uint8_t* nonce154,
                            uint8_t* buffer);
 
+static void reverse(uint8_t* in, uint8_t len);
+
 //=========================== public ==========================================
 
 owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
@@ -154,8 +156,13 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
 static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_index) {
    cc2420_status_t status;
 
+   uint8_t reversed[16];
+   memcpy(reversed, key, CC2420_KEY_LEN);
+   reverse(reversed, CC2420_KEY_LEN);
+
    // Load the key in key RAM
-   radio_spiWriteRam(CC2420_RAM_KEY0_ADDR, &status, key, CC2420_KEY_LEN);
+   radio_spiWriteRam(CC2420_RAM_KEY0_ADDR, &status, reversed, CC2420_KEY_LEN);
+
    *key_index = CC2420_SECCTRL0_KEY_SEL_KEY0;
    return E_SUCCESS;
 }
@@ -218,5 +225,16 @@ static void create_cc2420_nonce(uint8_t l,
    if (l == 3) { buffer[13] = 0; }
    buffer[14] = 0x00;
    buffer[15] = 0x00; // should this be zero or one?
+}
+
+static void reverse(uint8_t *start, uint8_t len) {
+   uint8_t *lo = start;
+   uint8_t *hi = start + len - 1;
+   uint8_t swap;
+   while (lo < hi) {
+      swap = *lo;
+      *lo++ = *hi;
+      *hi-- = swap;
+   }
 }
 

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -14,10 +14,17 @@
 
 #define CC2420_KEY_LEN        16
 
-#define CC2420_KEY_INDEX_0    0
-#define CC2420_KEY_INDEX_1    1
 //=========================== prototypes ======================================
 static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_index);
+
+static owerror_t cc2420_crypto_inline_ccms_enc(uint8_t* a,
+                                 uint8_t len_a,
+                                 uint8_t* m,
+                                 uint8_t* len_m,
+                                 uint8_t* nonce,
+                                 uint8_t l,
+                                 uint8_t key[16],
+                                 uint8_t len_mac);
 
 //=========================== public ==========================================
 
@@ -47,6 +54,38 @@ owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
       radio_spiReadRam(CC2420_RAM_SABUF_ADDR, &status, buffer, 16);
       return E_SUCCESS;
    }
+   return E_FAIL;
+}
+
+owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
+                        uint8_t len_a,
+                        uint8_t* m,
+                        uint8_t* len_m,
+                        uint8_t* nonce,
+                        uint8_t l,
+                        uint8_t key[16],
+                        uint8_t len_mac) {
+   // need to separate the calls to mimic CC2420 operation
+   // both encryption and authentication
+   if (len_mac > 0 && *len_m > 0) {
+      return cc2420_crypto_inline_ccms_enc(a,
+                                          len_a,
+                                          m,
+                                          len_m,
+                                          nonce,
+                                          l,
+                                          key,
+                                          len_mac);
+   }
+   // authentication only
+   else if (len_mac > 0 && *len_m == 0) {
+      return E_FAIL;
+   }
+   //encryption only (insecure)
+   else if (len_mac == 0 && *len_m > 0) {
+      return E_FAIL;
+   }
+   return E_FAIL;
 }
 
 //=========================== private =========================================
@@ -60,9 +99,133 @@ static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_
 
    // Load the key in key RAM
    radio_spiWriteRam(CC2420_RAM_KEY0_ADDR, &status, key, CC2420_KEY_LEN);
-   *key_index = CC2420_KEY_INDEX_0;
+   *key_index = CC2420_SECCTRL0_KEY_SEL_KEY0;
    return E_SUCCESS;
 }
 
+// private function supporting only authentication + encryption 
+static owerror_t cc2420_crypto_inline_ccms_enc(uint8_t* a,
+                                 uint8_t len_a,
+                                 uint8_t* m,
+                                 uint8_t* len_m,
+                                 uint8_t* nonce,
+                                 uint8_t l,
+                                 uint8_t key[16],
+                                 uint8_t len_mac) {
+   uint8_t key_index;
+   uint8_t buffer[128];
+   uint8_t cc2420_nonce[16];
+   uint8_t total_message_len;
+   cc2420_SECCTRL0_reg_t cc2420_SECCTRL0_reg;
+   cc2420_SECCTRL1_reg_t cc2420_SECCTRL1_reg;
+   cc2420_status_t status;
+
+
+   if (!((len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
+      return E_FAIL;
+   }
+
+   if (*len_m > 125 || *len_m == 0) {
+      return E_FAIL;
+   }
+
+   // CRC needs to be accounted for in the message len but does not affect encryption
+   total_message_len = len_a + *len_m + len_mac + LENGTH_CRC;
+
+   if (total_message_len > 127) {
+      return E_FAIL;
+   }
+
+
+   // load key
+   if (cc2420_crypto_load_key(key, &key_index) == E_SUCCESS) {
+               // make sure the Additional Data is concatenated with plaintext
+               memcpy(buffer, a, len_a);
+               memcpy(&buffer[len_a], m, *len_m);
+               memcpy(&buffer[len_a + *len_m], 0x00, len_mac ); // CC2420 expects MIC and CRC bytes allocated 
+
+               // load in tx buffer the concatenated message in order to use inline encryption mode
+               radio_spiWriteTxFifo(&status, buffer, total_message_len);
+
+
+               //configure SECCTRL0 and SECTRL1
+               // key selection for TX
+               // write nonce for TX
+               // SECCTRL0.SEC_MODE = CCM
+
+               cc2420_SECCTRL0_reg.SEC_MODE = CC2420_SECCTRL0_SEC_MODE_CCM;
+               cc2420_SECCTRL0_reg.SEC_M = (len_mac - 2) >> 1; // (M-2)/2
+               cc2420_SECCTRL0_reg.SEC_RXKEYSEL = 0;
+               cc2420_SECCTRL0_reg.SEC_TXKEYSEL = key_index;
+               cc2420_SECCTRL0_reg.SEC_SAKEYSEL = 0;
+               cc2420_SECCTRL0_reg.SEC_CBC_HEAD = 1; // use len_a as first byte of authenticated data
+               cc2420_SECCTRL0_reg.RXFIFO_PROTECTION = 0;
+               cc2420_SECCTRL0_reg.reserved_w0 = 0;
+
+               /// Security Control Register 1
+               cc2420_SECCTRL1_reg.SEC_RXL = 0;
+               cc2420_SECCTRL1_reg.reserved_1_w0 = 0;
+               cc2420_SECCTRL1_reg.SEC_TXL = len_a; // number of bytes until first encrypted byte
+               cc2420_SECCTRL1_reg.reserved_2_w0 = 0;
+
+               cc2420_nonce[0] = 0x00; // set flags to zero including reserved
+               cc2420_nonce[0] |= 0x07 & (l-1); // field L
+               // (len_mac - 2)/2 shifted left 3 times corresponds to (len_mac - 2) << 2
+               cc2420_nonce[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
+               cc2420_nonce[0] |= len_a != 0 ? 0x40 : 0; // field Adata
+   
+               memcpy(&cc2420_nonce[1], nonce, 13);
+
+               if (l == 3) {
+                  cc2420_nonce[13] = 0;
+               }
+
+               cc2420_nonce[14] = 0x00;
+               cc2420_nonce[15] = 0x00; // should this be zero or one?
+               
+               // Write the nonce to the CC2420 RAM
+               radio_spiWriteRam(CC2420_RAM_TXNONCE_ADDR, &status, cc2420_nonce, 16);
+
+               // Write to two CC2420 security registers
+               radio_spiWriteReg(CC2420_SECCTRL0_ADDR, 
+                     &status,
+                     *(uint16_t*)&cc2420_SECCTRL0_reg);
+               
+               radio_spiWriteReg(CC2420_SECCTRL1_ADDR, 
+                     &status,
+                     *(uint16_t*)&cc2420_SECCTRL1_reg);
+
+               // issue STXENC to encrypt but not start the transmission
+               radio_spiStrobe(CC2420_STXENC, &status);
+               while (status.enc_busy == 1) {
+                  radio_spiStrobe(CC2420_SNOP, &status);
+               }
+ 
+               // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
+               radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR,
+                         &status,
+                         buffer,
+                         total_message_len + 1); // plus one for the length byte
+
+               if (buffer[0] != total_message_len) {
+                  return E_FAIL;
+               }
+
+               // Write ciphertext to vector m[]
+               radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + len_a, // one for the length byte
+                         &status,
+                         m,
+                         *len_m + len_mac); // ciphertext plus MIC
+
+               *len_m += len_mac;
+
+               // flush TX Fifo ???
+               radio_spiStrobe(CC2420_SFLUSHTX, &status);
+               radio_spiStrobe(CC2420_SFLUSHTX, &status);
+
+               return E_SUCCESS;
+   }
+   return E_FAIL;
+}
 
 

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -129,16 +129,6 @@ owerror_t cc2420_crypto_ccms_dec(uint8_t* a,
          radio_spiStrobe(CC2420_SNOP, &status);
       } while (status.enc_busy == 1);
 
-      // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
-      radio_spiReadRam(CC2420_RAM_RXFIFO_ADDR,
-                         &status,
-                         buffer,
-                         total_message_len + 1); // plus one for the length byte
-      // assert on message len
-      if (buffer[0] != total_message_len) {
-         return E_FAIL;
-      }
-
       radio_spiReadRam(CC2420_RAM_RXFIFO_ADDR + 1 + len_a, // one for the length byte
                          &status,
                          buffer,
@@ -212,16 +202,6 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
       do {
          radio_spiStrobe(CC2420_SNOP, &status);
       } while (status.enc_busy == 1);
-
-      // FOR DEBUGGING: read the ciphertext from TX fifo with ReadRam()
-      radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR,
-                         &status,
-                         buffer,
-                         total_message_len + 1); // plus one for the length byte
-      // assert on message len
-      if (buffer[0] != total_message_len) {
-         return E_FAIL;
-      }
 
       // Write ciphertext to vector m[]
       radio_spiReadRam(CC2420_RAM_TXFIFO_ADDR + 1 + len_a, // one for the length byte

--- a/bsp/chips/cc2420/cc2420_crypto.c
+++ b/bsp/chips/cc2420/cc2420_crypto.c
@@ -1,0 +1,68 @@
+/**
+\brief CC2420-specific implementation of AES encryption.
+
+\author Malisa Vucinic <malishav@gmail.com>, April 2015.
+*/
+
+#include "opendefs.h"
+#include "board.h"
+#include "radio.h"
+#include "cc2420.h"
+#include "cc2420_crypto.h"
+#include "spi.h"
+#include "debugpins.h"
+
+#define CC2420_KEY_LEN        16
+
+#define CC2420_KEY_INDEX_0    0
+#define CC2420_KEY_INDEX_1    1
+//=========================== prototypes ======================================
+static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_index);
+
+//=========================== public ==========================================
+
+owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
+   cc2420_SECCTRL0_reg_t cc2420_SECCTRL0_reg;
+   cc2420_status_t status;
+   uint8_t key_index;
+
+   if (cc2420_crypto_load_key(key, &key_index) == E_SUCCESS) {
+      memset(&cc2420_SECCTRL0_reg, 0x00, sizeof(cc2420_SECCTRL0_reg_t));
+      // configure the SECCTRL register to use the loaded key
+      cc2420_SECCTRL0_reg.SEC_SAKEYSEL = key_index;
+      radio_spiWriteReg(CC2420_SECCTRL0_ADDR, 
+                     &status,
+                     *(uint16_t*)&cc2420_SECCTRL0_reg);
+
+      // write plaintext to the stand-alone buffer
+      radio_spiWriteRam(CC2420_RAM_SABUF_ADDR, &status, buffer, 16);
+      
+      // launch stand-alone AES encryption
+      radio_spiStrobe(CC2420_SAES, &status);
+      while (status.enc_busy == 1) {
+         radio_spiStrobe(CC2420_SNOP, &status);
+      }
+      
+      // read the ciphertext and overwrite the original buffer
+      radio_spiReadRam(CC2420_RAM_SABUF_ADDR, &status, buffer, 16);
+      return E_SUCCESS;
+   }
+}
+
+//=========================== private =========================================
+
+/**
+\brief On success, returns by reference the location in key RAM where the 
+   new/existing key is stored.
+*/
+static owerror_t cc2420_crypto_load_key(uint8_t key[16], uint8_t* /* out */ key_index) {
+   cc2420_status_t status;
+
+   // Load the key in key RAM
+   radio_spiWriteRam(CC2420_RAM_KEY0_ADDR, &status, key, CC2420_KEY_LEN);
+   *key_index = CC2420_KEY_INDEX_0;
+   return E_SUCCESS;
+}
+
+
+

--- a/bsp/chips/cc2420/cc2420_crypto.h
+++ b/bsp/chips/cc2420/cc2420_crypto.h
@@ -30,4 +30,13 @@ owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
                         uint8_t key[16],
                         uint8_t len_mac);
 
+owerror_t cc2420_crypto_ccms_dec(uint8_t* a,
+                        uint8_t len_a,
+                        uint8_t* m,
+                        uint8_t* len_m,
+                        uint8_t* nonce,
+                        uint8_t l,
+                        uint8_t key[16],
+                        uint8_t len_mac);
+
 #endif /* __CC2420_CRYPTO_H__ */

--- a/bsp/chips/cc2420/cc2420_crypto.h
+++ b/bsp/chips/cc2420/cc2420_crypto.h
@@ -13,10 +13,6 @@
 #define CC2420_SECCTRL0_SEC_MODE_CTR         2
 #define CC2420_SECCTRL0_SEC_MODE_CCM         3
 
-// Generic Key Selector
-#define CC2420_SECCTRL0_KEY_SEL_KEY0         0
-#define CC2420_SECCTRL0_KEY_SEL_KEY1         1
-
 //=========================== prototypes ======================================
 
 owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key);

--- a/bsp/chips/cc2420/cc2420_crypto.h
+++ b/bsp/chips/cc2420/cc2420_crypto.h
@@ -6,8 +6,28 @@
 #ifndef __CC2420_CRYPTO_H__
 #define __CC2420_CRYPTO_H__
 
+//=========================== SECCTRL0 values =================================
+// SEC_MODE[1:0]
+#define CC2420_SECCTRL0_SEC_MODE_DISABLE     0
+#define CC2420_SECCTRL0_SEC_MODE_CBC_MAC     1
+#define CC2420_SECCTRL0_SEC_MODE_CTR         2
+#define CC2420_SECCTRL0_SEC_MODE_CCM         3
+
+// Generic Key Selector
+#define CC2420_SECCTRL0_KEY_SEL_KEY0         0
+#define CC2420_SECCTRL0_KEY_SEL_KEY1         1
+
 //=========================== prototypes ======================================
 
 owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key);
+
+owerror_t cc2420_crypto_ccms_enc(uint8_t* a,
+                        uint8_t len_a,
+                        uint8_t* m,
+                        uint8_t* len_m,
+                        uint8_t* nonce,
+                        uint8_t l,
+                        uint8_t key[16],
+                        uint8_t len_mac);
 
 #endif /* __CC2420_CRYPTO_H__ */

--- a/bsp/chips/cc2420/cc2420_crypto.h
+++ b/bsp/chips/cc2420/cc2420_crypto.h
@@ -1,0 +1,13 @@
+/**
+\brief CC2420-specific crypto library with hardware acceleration.
+
+\author Malisa Vucinic <malishav@gmail.com>, April 2015.
+*/
+#ifndef __CC2420_CRYPTO_H__
+#define __CC2420_CRYPTO_H__
+
+//=========================== prototypes ======================================
+
+owerror_t cc2420_crypto_aes_ecb_enc(uint8_t* buffer, uint8_t* key);
+
+#endif /* __CC2420_CRYPTO_H__ */

--- a/bsp/chips/cc2420/radio.c
+++ b/bsp/chips/cc2420/radio.c
@@ -203,7 +203,7 @@ void radio_loadPacket(uint8_t* packet, uint8_t len) {
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
    
    radio_spiStrobe(CC2420_SFLUSHTX, &radio_vars.radioStatusByte);
-   radio_spiWriteTxFifo(&radio_vars.radioStatusByte, packet, len);
+   radio_spiWriteFifo(&radio_vars.radioStatusByte, packet, len, CC2420_TXFIFO_ADDR);
    
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;

--- a/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
+++ b/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
@@ -497,7 +497,7 @@ int mote_main(void) {
 #if TEST_BENCHMARK_CCMS
 
 #define A_LEN 30
-#define M_LEN 93
+#define M_LEN 91
 #define TAG_LEN 4
 #define L 2
 

--- a/projects/telosb/SConscript.env
+++ b/projects/telosb/SConscript.env
@@ -31,4 +31,8 @@ elif buildEnv['toolchain']=='iar':
    buildEnv.Append(CCFLAGS        = '-D__MSP430F{0}__'.format(MSPVERSION))
    buildEnv.Append(LINKFLAGS      = '-f "'+env['IAR_EW430_INSTALLDIR']+'\\430\\config\\linker\\lnk430F{0}.xcl"'.format(MSPVERSION))
 
+# Use hardware accelerated crypto engine by default 
+if not env['cryptoengine']:
+   buildEnv.Append(CPPDEFINES    = {'CRYPTO_ENGINE_SCONS': 'board_crypto_engine'})
+
 Return('buildEnv')


### PR DESCRIPTION
This pull request implements CC2420 hardware-accelerated encryption functions and uses it for TelosB's crypto engine. Stand-alone, 16 byte AES buffer of CC2420 is used for ECB encryption mode. CCM* is implemented by leveraging the in-line functionality of CC2420. CCM* encryption/decryption take place in TX/RX FIFO buffers, respectively. The implementation successfully passes the test suite but has not been fully optimized yet.