### PR TITLE
FW-373. Prefix cc2420.c functions with 'cc2420_'.

### DIFF
--- a/bsp/chips/cc2420/cc2420.c
+++ b/bsp/chips/cc2420/cc2420.c
@@ -9,7 +9,7 @@
 #include "spi.h"
 
 
-void radio_spiStrobe(uint8_t strobe, cc2420_status_t* statusRead) {
+void cc2420_spiStrobe(uint8_t strobe, cc2420_status_t* statusRead) {
    uint8_t  spi_tx_buffer[1];
    
    spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | strobe);
@@ -25,7 +25,7 @@ void radio_spiStrobe(uint8_t strobe, cc2420_status_t* statusRead) {
    );
 }
 
-void radio_spiWriteReg(uint8_t reg, cc2420_status_t* statusRead, uint16_t regValueToWrite) {
+void cc2420_spiWriteReg(uint8_t reg, cc2420_status_t* statusRead, uint16_t regValueToWrite) {
    uint8_t              spi_tx_buffer[3];
    
    spi_tx_buffer[0]     = (CC2420_FLAG_WRITE | CC2420_FLAG_REG | reg);
@@ -43,7 +43,7 @@ void radio_spiWriteReg(uint8_t reg, cc2420_status_t* statusRead, uint16_t regVal
    );
 }
 
-void radio_spiReadReg(uint8_t reg, cc2420_status_t* statusRead, uint8_t* regValueRead) {
+void cc2420_spiReadReg(uint8_t reg, cc2420_status_t* statusRead, uint8_t* regValueRead) {
    uint8_t              spi_tx_buffer[3];
    uint8_t              spi_rx_buffer[3];
    
@@ -66,7 +66,7 @@ void radio_spiReadReg(uint8_t reg, cc2420_status_t* statusRead, uint8_t* regValu
    *(regValueRead+1)    = spi_rx_buffer[1];
 }
 
-void radio_spiWriteFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len, uint8_t addr) {
+void cc2420_spiWriteFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t len, uint8_t addr) {
    uint8_t              spi_tx_buffer[2];
    
    // step 1. send SPI address and length byte
@@ -95,7 +95,7 @@ void radio_spiWriteFifo(cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_
    );
 }
 
-void radio_spiReadRxFifo(cc2420_status_t* statusRead,
+void cc2420_spiReadRxFifo(cc2420_status_t* statusRead,
                          uint8_t*         pBufRead,
                          uint8_t*         pLenRead,
                          uint8_t          maxBufLen) {
@@ -160,14 +160,14 @@ void radio_spiReadRxFifo(cc2420_status_t* statusRead,
       goes back to its inactive state.
       */
       
-      radio_spiStrobe(CC2420_SFLUSHRX, statusRead);
-      radio_spiStrobe(CC2420_SFLUSHRX, statusRead);
+      cc2420_spiStrobe(CC2420_SFLUSHRX, statusRead);
+      cc2420_spiStrobe(CC2420_SFLUSHRX, statusRead);
       
 
    }
 }
 
-void radio_spiReadRam(uint16_t addr,
+void cc2420_spiReadRam(uint16_t addr,
                          cc2420_status_t* statusRead,
                          uint8_t*         pBufRead,
                          uint8_t          len) {
@@ -204,7 +204,7 @@ void radio_spiReadRam(uint16_t addr,
    );
 }
 
-void radio_spiWriteRam(uint16_t addr,
+void cc2420_spiWriteRam(uint16_t addr,
                         cc2420_status_t* statusRead,
                         uint8_t* bufToWrite,
                         uint8_t len) {

--- a/bsp/chips/cc2420/cc2420.h
+++ b/bsp/chips/cc2420/cc2420.h
@@ -426,12 +426,12 @@ typedef struct {
 
 //=========================== prototypes ======================================
 
-void radio_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);
-void radio_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t regValueToWrite);
-void radio_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
-void radio_spiWriteFifo(                  cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite, uint8_t addr);
-void radio_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
-void radio_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
-void radio_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);
+void cc2420_spiStrobe     (uint8_t strobe, cc2420_status_t* statusRead);
+void cc2420_spiWriteReg   (uint8_t reg,    cc2420_status_t* statusRead, uint16_t regValueToWrite);
+void cc2420_spiReadReg    (uint8_t reg,    cc2420_status_t* statusRead, uint8_t* regValueRead);
+void cc2420_spiWriteFifo(                  cc2420_status_t* statusRead, uint8_t* bufToWrite, uint8_t  lenToWrite, uint8_t addr);
+void cc2420_spiReadRxFifo (                cc2420_status_t* statusRead, uint8_t* bufRead,    uint8_t* lenRead, uint8_t maxBufLen);
+void cc2420_spiWriteRam   (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* bufToWrite,  uint8_t len);
+void cc2420_spiReadRam    (uint16_t addr,  cc2420_status_t* statusRead, uint8_t* pBufRead,    uint8_t len);
 
 #endif


### PR DESCRIPTION
This PR prefixes the functions in ```chips/cc2420/cc2420.c``` library with ```cc2420_``` instead of ```radio_``` in order to match the new structure.