### PR TITLE
always include Python.h first

### DIFF
--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -952,8 +952,15 @@ def objectify(env,target,source):
             )
     
     #=== .h files only
-    
+
     if headerFile:
+        # include Python.h first
+        lines = re.sub(
+            r'(#include [<"]\w+\.h[>"])',
+            r'#include "Python.h"\n\n\1',
+            lines,
+            count=1
+            )
         
         # include openwsnmodule
         lines = re.sub(


### PR DESCRIPTION
Fixes https://openwsn.atlassian.net/browse/FW-375

The compiler warnings get eliminated according to https://docs.python.org/3.2/c-api/intro.html#include-files by making sure that `Python.h` is always included first.