### PR TITLE
FW-379. Integrate bootloader for IoT-LAB_M3 motes.

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -506,10 +506,14 @@ def IotLabM3_bootload(target, source, env):
     countingSem     = threading.Semaphore(0)
     # create threads
     for comPort in env['bootload'].split(','):
+        if os.name=='nt':
+            suffix = '.exe'
+        else:
+            suffix = ''
         bootloadThreads += [
             IotLabM3_bootloadThread(
                 comPort      = comPort,
-                binaryFile   = source[0].path.split('.')[0],
+                binaryFile   = source[0].path.split('.')[0]+suffix,
                 countingSem  = countingSem,
             )
         ]

--- a/SConscript
+++ b/SConscript
@@ -478,6 +478,48 @@ def OpenMoteCC2538_bootload(target, source, env):
     for t in bootloadThreads:
         countingSem.acquire()
 
+class IotLabM3_bootloadThread(threading.Thread):
+    def __init__(self,comPort,binaryFile,countingSem):
+        
+        # store params
+        self.comPort         = comPort
+        self.binaryFile      = binaryFile
+        self.countingSem     = countingSem
+        
+        # initialize parent class
+        threading.Thread.__init__(self)
+        self.name            = 'IotLabM3_bootloadThread_{0}'.format(self.comPort)
+    
+    def run(self):
+        print 'starting bootloading on {0}'.format(self.comPort)
+        subprocess.call(
+            'python '+ os.path.join('bootloader','iot-lab_M3','iotlab-m3-bsl.py' + ' -i {0} -p {1}'.format(self.binaryFile, self.comPort)),
+            shell=True
+        )
+        print 'done bootloading on {0}'.format(self.comPort)
+        
+        # indicate done
+        self.countingSem.release()
+        
+def IotLabM3_bootload(target, source, env):
+    bootloadThreads = []
+    countingSem     = threading.Semaphore(0)
+    # create threads
+    for comPort in env['bootload'].split(','):
+        bootloadThreads += [
+            IotLabM3_bootloadThread(
+                comPort      = comPort,
+                binaryFile   = source[0].path.split('.')[0],
+                countingSem  = countingSem,
+            )
+        ]
+    # start threads
+    for t in bootloadThreads:
+        t.start()
+    # wait for threads to finish
+    for t in bootloadThreads:
+        countingSem.acquire()
+
 # bootload
 def BootloadFunc():
     if   env['board']=='telosb':
@@ -492,6 +534,12 @@ def BootloadFunc():
             suffix      = '.phonyupload',
             src_suffix  = '.bin',
         )
+    elif env['board']=='iot-lab_M3':
+         return Builder(
+            action      = IotLabM3_bootload,
+            suffix      = '.phonyupload',
+            src_suffix  = ''
+         )
     else:
         raise SystemError('bootloading on board={0} unsupported.'.format(env['board']))
 if env['bootload']:

--- a/bootloader/iot-lab_M3/README
+++ b/bootloader/iot-lab_M3/README
@@ -1,0 +1,47 @@
+-------------------------------------------------------------------------------
+Windows environment config in order to program (i.e. flash) iot-lab_M3.
+-------------------------------------------------------------------------------
+
+1. Download openocd Windows binary package from http://openocd.org/
+
+2. Extract to C:\openocd or similar
+
+3. Add to PATH the openocd directory containing binaries (C:\openocd\bin for 32
+bit or C:\openocd\bin-x64 for 64 bit machines).  
+
+4. Rename openocd executable from openocd-xxx-x.x.x.exe to openocd.exe. OpenWSN
+python script expects openocd.exe to be found in the PATH. Test by issuing 
+openocd.exe in a cmd prompt.
+
+5. Connect the iot-lab_M3 node to the USB port.
+
+6. Download Zadig from http://zadig.akeo.ie/ which we will use to install 
+libusb-win32 drivers that openocd requires.
+
+7. Open the Zadig executable. Click Options -> List All Devices
+
+8. Two entries corresponding to the same iot-lab_M3 node should appear: 
+1) M3 (Interface 0); 2) M3 (Interface 1). For interfacing with openocd, one of 
+the two ports must be associated with the OpenOCD usb-win32_ft2232 driver 
+available in the OpenOCD installation [1]. We will use M3 (Interface 0). 
+Select M3 (Interface 0) from the drop down list in Zadig. Select 
+libusb-win32 (xxx) driver and click on the button to replace/install the 
+driver for this interface. Once this is done successfully, openocd in Windows 
+can interact with IoT-lab_M3 node and flash it. 
+
+9. To flash, use the OpenWSN workflow in openwsn-fw/ dir:
+scons board=iot-lab_M3 toolchain=armgcc bootload=0
+
+NOTE: openocd does not support flashing using typical /dev/ttyUSB* or COMX 
+interfaces. The Python script will flash the first *iot-lab_M3* node 
+connected to the PC, independent of the bootload argument value.  
+
+
+[1] https://github.com/hikob/openlab/wiki/Installation-Notes-for-Windows-Users]
+
+-------------------------------------------------------------------------------
+Linux:
+-------------------------------------------------------------------------------
+1. install openocd by issuing 'sudo apt-get install openocd'
+2. To flash, use the OpenWSN workflow as in step 9 of the Windows manual.
+

--- a/bootloader/iot-lab_M3/iotlab-m3-bsl.py
+++ b/bootloader/iot-lab_M3/iotlab-m3-bsl.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+import sys
+import getopt
+import os.path
+from subprocess import call
+
+currentDir = os.path.dirname(os.path.realpath(__file__))
+
+OOCD_TARGET='stm32f1x'
+OOCD_ITF=os.path.join(currentDir, 'iotlab-m3.cfg')
+
+OOCD_PORT = '123'
+GDB_PORT = '3' + OOCD_PORT
+TELNET_PORT = '4' + OOCD_PORT
+TCL_PORT = '5' + OOCD_PORT
+
+def usage():
+    print("""Usage: %s [-i binary file] [-p port] 
+Examples:
+    ./%s example/main -p /dev/ttyUSB0 
+    """ % (sys.argv[0], sys.argv[0]))
+
+
+# from http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+def which(program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    raise RuntimeError('Command not found.')
+
+try:
+   OPENOCD = which('openocd')
+except RuntimeError as e:
+    print('ERROR: {} requires OpenOCD with ft2232 interface.'.format(sys.argv[0]))
+    print('')
+    sys.exit(1)
+
+try:
+   opts, args = getopt.getopt(sys.argv[1:], "hi:p:", ["help", "input=","port="])
+except getopt.GetoptError as err:
+   # print help information and exit:
+   print str(err) # will print something like "option -a not recognized"
+   usage()
+   sys.exit(2)
+binary = None
+port = '0'
+for o, a in opts:
+   if o in ("-h", "--help"):
+      usage()
+      sys.exit()
+   elif o in ("-i", "--input"):
+      binary = a
+   elif o in ("-p", "--port"):
+      port = a
+   else:
+      assert False, "unhandled option" 
+
+try: 
+   os.path.isfile(binary)
+except:
+   print('ERROR: Binary file not found/specified.')
+   usage()
+   sys.exit(2)
+
+call([OPENOCD,
+   '-f', os.path.join(currentDir, OOCD_ITF),
+   '-f', os.path.join('target', OOCD_TARGET) + '.cfg',
+   '-c', 'gdb_port ' + GDB_PORT,
+   '-c', 'telnet_port ' + TELNET_PORT,
+   '-c', 'tcl_port ' + TCL_PORT,
+   '-c', 'init',
+   '-c', 'targets',
+   '-c', 'reset halt',
+   '-c', 'reset init', 
+   '-c', 'flash write_image erase ' + binary,
+   '-c', 'verify_image ' + binary,
+   '-c', 'reset run',
+   '-c', 'shutdown'])

--- a/bootloader/iot-lab_M3/iotlab-m3-bsl.py
+++ b/bootloader/iot-lab_M3/iotlab-m3-bsl.py
@@ -14,6 +14,11 @@ GDB_PORT = '3' + OOCD_PORT
 TELNET_PORT = '4' + OOCD_PORT
 TCL_PORT = '5' + OOCD_PORT
 
+if os.name=='nt':
+   extension = '.exe'
+else:
+   extension = ''
+
 def usage():
     print("""Usage: %s [-i binary file] [-p port] 
 Examples:
@@ -40,7 +45,7 @@ def which(program):
     raise RuntimeError('Command not found.')
 
 try:
-   OPENOCD = which('openocd')
+   OPENOCD = which('openocd' + extension)
 except RuntimeError as e:
     print('ERROR: {} requires OpenOCD with ft2232 interface.'.format(sys.argv[0]))
     print('')
@@ -72,6 +77,9 @@ except:
    print('ERROR: Binary file not found/specified.')
    usage()
    sys.exit(2)
+
+if os.name=='nt':
+   binary = '{' + binary + '}'
 
 call([OPENOCD,
    '-f', os.path.join(currentDir, OOCD_ITF),

--- a/bootloader/iot-lab_M3/iotlab-m3.cfg
+++ b/bootloader/iot-lab_M3/iotlab-m3.cfg
@@ -1,0 +1,16 @@
+# Copied from iot-lab/parts/openlab/platform/scripts/iotlab-m3.cfg
+
+adapter_khz 1000
+
+# comstick ftdi device
+interface ft2232
+ft2232_layout "usbjtag"
+ft2232_device_desc "M3"
+ft2232_vid_pid 0x0403 0x6010
+
+jtag_nsrst_delay 100
+jtag_ntrst_delay 100
+
+# use combined on interfaces or targets that can't set TRST/SRST separately
+reset_config trst_and_srst
+


### PR DESCRIPTION
This PR implements the Python version of bootloading script for IoT-LAB_M3 nodes and integrates it with the OpenWSN scons build.

Since programming of IoT-LAB_M3 nodes is done using openocd, which to my knowledge does not support interfacing with devices over /dev/ttyUSB* or COMX ports, the BSL script flashes the first IoT-LAB_M3 node found connected to the PC, independent of the bootload argument passed to SCons.

The PR also contains a README file  (bootloader/iot-lab_M3/README) that explains the necessary steps in order to configure the Windows environment. 

To flash an IoT-LAB_M3 node, the user should follow  the typical OpenWSN workflow with bootload option present:
scons board=iot-lab_M3 toolchain=armgcc bootload=0 oos_openwsn