### PR TITLE
FW-392. Fixed.

### DIFF
--- a/openstack/02a-MAClow/IEEE802154.c
+++ b/openstack/02a-MAClow/IEEE802154.c
@@ -1,5 +1,7 @@
 #include "opendefs.h"
 #include "IEEE802154.h"
+#include "IEEE802154e.h"
+#include "processIE.h" 
 #include "packetfunctions.h"
 #include "idmanager.h"
 #include "openserial.h"
@@ -48,6 +50,8 @@ void ieee802154_prependHeader(OpenQueueEntry_t* msg,
    uint8_t temp_8b;
    uint8_t ielistpresent = IEEE154_IELIST_NO;
    uint8_t frameVersion;
+   int16_t timeCorrection;
+   header_IE_ht header_desc;
    
    // General IEs here (those that are carried in all packets)
    // add termination IE accordingly 
@@ -72,9 +76,34 @@ void ieee802154_prependHeader(OpenQueueEntry_t* msg,
            msg->payload[0] = (Header_Payload_TerminationIE >> 8) & 0xFF;
            msg->payload[1] = Header_Payload_TerminationIE        & 0xFF;
        } else {
-           // no payload, termination IE is omitted
-           frameVersion = IEEE154_FRAMEVERSION_2006;
+           // no payload, termination IE is omitted. check whether timeCorrection IE
+           // presents. 
+           if (frameType != IEEE154_TYPE_ACK) {
+               frameVersion = IEEE154_FRAMEVERSION_2006;
+           } else {
+               ielistpresent = IEEE154_IELIST_YES; // I will have a timeCorrection IE later
+               frameVersion = IEEE154_FRAMEVERSION;
+           }
        }
+   }
+   
+   if (frameType == IEEE154_TYPE_ACK) {
+       timeCorrection = ieee154e_getTimeCorrection();
+       // add the payload to the ACK (i.e. the timeCorrection)
+       packetfunctions_reserveHeaderSize(msg,sizeof(timecorrection_IE_ht));
+       timeCorrection  = -timeCorrection;
+       timeCorrection *= US_PER_TICK;
+       msg->payload[0] = (uint8_t)((((uint16_t)timeCorrection)   ) & 0xff);
+       msg->payload[1] = (uint8_t)((((uint16_t)timeCorrection)>>8) & 0xff);
+       
+       // add header IE header -- xv poipoi -- pkt is filled in reverse order..
+       packetfunctions_reserveHeaderSize(msg,sizeof(header_IE_ht));
+       //create the header for ack IE
+       header_desc.length_elementid_type=(sizeof(timecorrection_IE_ht)<< IEEE802154E_DESC_LEN_HEADER_IE_SHIFT)|
+                                         (IEEE802154E_ACK_NACK_TIMECORRECTION_ELEMENTID << IEEE802154E_DESC_ELEMENTID_HEADER_IE_SHIFT)|
+                                         IEEE802154E_DESC_TYPE_SHORT; 
+       msg->payload[0] = ((header_desc.length_elementid_type) >> 8) & 0xFF;
+       msg->payload[1] = (header_desc.length_elementid_type)        & 0xFF;
    }
    
    // previousHop address (always 64-bit)
@@ -153,11 +182,11 @@ void ieee802154_retrieveHeader(OpenQueueEntry_t*      msg,
                                ieee802154_header_iht* ieee802514_header) {
    uint8_t  temp_8b;
    uint16_t temp_16b;
-   
-   if (msg->length > 70 && msg->length < 80) {
-       ieee802514_header->valid=FALSE;
-   }
-   
+   uint16_t len;
+   uint8_t  gr_elem_id;
+   uint8_t  byte0;
+   uint8_t  byte1;
+   int16_t  timeCorrection;
    // by default, let's assume the header is not valid, in case we leave this
    // function because the packet ends up being shorter than the header.
    ieee802514_header->valid=FALSE;
@@ -295,8 +324,33 @@ void ieee802154_retrieveHeader(OpenQueueEntry_t*      msg,
            }
            if (temp_16b == Header_Payload_TerminationIE) {
                // I have payload following
+               msg->l2_payloadIEpresent = FALSE;
                break;
            }
+           if ((temp_16b & IEEE802154E_DESC_TYPE_PAYLOAD_IE) != IEEE802154E_DESC_TYPE_PAYLOAD_IE) {
+               // only process header IE here
+               len          = (temp_16b & IEEE802154E_DESC_LEN_HEADER_IE_MASK)>>IEEE802154E_DESC_LEN_HEADER_IE_SHIFT;
+               gr_elem_id   = (temp_16b & IEEE802154E_DESC_ELEMENTID_HEADER_IE_MASK)>>IEEE802154E_DESC_ELEMENTID_HEADER_IE_SHIFT;
+              
+               switch(gr_elem_id){
+                   case IEEE802154E_ACK_NACK_TIMECORRECTION_ELEMENTID:
+                          // timecorrection IE
+                          
+                          byte0 = *((uint8_t*)(msg->payload));
+                          byte1 = *((uint8_t*)(msg->payload)+1);
+
+                          timeCorrection  = (int16_t)((uint16_t)byte1<<8 | (uint16_t)byte0);
+                          timeCorrection  = (timeCorrection / (PORT_SIGNED_INT_WIDTH)US_PER_TICK);
+                          timeCorrection  = -timeCorrection;
+                          
+                          ieee802514_header->timeCorrection = timeCorrection;
+                          ieee802514_header->headerLength  += 2;
+                       break;
+                   default:
+                       break;
+               }
+           }
+           
            if (ieee802514_header->headerLength>msg->length) {  return; } // no more to read!
        }
    }

--- a/openstack/02a-MAClow/IEEE802154.c
+++ b/openstack/02a-MAClow/IEEE802154.c
@@ -1,6 +1,6 @@
 #include "opendefs.h"
 #include "IEEE802154.h"
-#include "IEEE802154e.h"
+#include "IEEE802154E.h"
 #include "processIE.h" 
 #include "packetfunctions.h"
 #include "idmanager.h"

--- a/openstack/02a-MAClow/IEEE802154.h
+++ b/openstack/02a-MAClow/IEEE802154.h
@@ -86,6 +86,7 @@ typedef struct {
    open_addr_t panid;
    open_addr_t dest;
    open_addr_t src;
+   int16_t     timeCorrection;
 } ieee802154_header_iht; //iht for "internal header type"
 
 //=========================== variables =======================================

--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -1146,7 +1146,6 @@ port_INLINE void activity_tie6() {
 
 port_INLINE void activity_ti9(PORT_RADIOTIMER_WIDTH capturedTime) {
    ieee802154_header_iht     ieee802514_header;
-   uint16_t                  lenIE;
    
    // change state
    changeState(S_TXPROC);
@@ -1246,9 +1245,6 @@ port_INLINE void activity_ti9(PORT_RADIOTIMER_WIDTH capturedTime) {
          ) {
          synchronizeAck(ieee802514_header.timeCorrection);
       }
- 
-      // toss the IEs
-      packetfunctions_tossHeader(ieee154e_vars.ackReceived,lenIE);
       
       // inform schedule of successful transmission
       schedule_indicateTx(&ieee154e_vars.asn,TRUE);
@@ -1490,8 +1486,6 @@ port_INLINE void activity_ri5(PORT_RADIOTIMER_WIDTH capturedTime) {
 }
 
 port_INLINE void activity_ri6() {
-   int16_t timeCorrection;
-   header_IE_ht header_desc;
    
    // change state
    changeState(S_TXACKPREPARE);
@@ -1524,7 +1518,7 @@ port_INLINE void activity_ri6() {
    ieee154e_vars.ackToSend->l2_dsn       = ieee154e_vars.dataReceived->l2_dsn;
    ieee802154_prependHeader(ieee154e_vars.ackToSend,
                             ieee154e_vars.ackToSend->l2_frameType,
-                            TRUE,//ie in ack
+                            FALSE,//no payloadIE in ack
                             IEEE154_SEC_NO_SECURITY,
                             ieee154e_vars.dataReceived->l2_dsn,
                             &(ieee154e_vars.dataReceived->l2_nextORpreviousHop)
@@ -1734,8 +1728,12 @@ port_INLINE void ieee154e_getAsn(uint8_t* array) {
    array[4]         =  ieee154e_vars.asn.byte4;
 }
 
-PORT_SIGNED_INT_WIDTH   ieee154e_getTimeCorrection() {
-    return ieee154e_vars.timeCorrection;
+port_INLINE uint16_t ieee154e_getTimeCorrection() {
+    int16_t returnVal;
+    
+    returnVal = (uint16_t)(ieee154e_vars.timeCorrection);
+    
+    return returnVal;
 }
 
 port_INLINE void joinPriorityStoreFromEB(uint8_t jp){

--- a/openstack/02a-MAClow/IEEE802154E.h
+++ b/openstack/02a-MAClow/IEEE802154E.h
@@ -218,6 +218,9 @@ typedef struct {
    PORT_RADIOTIMER_WIDTH     radioOnInit;             // when within the slot the radio turns on
    PORT_RADIOTIMER_WIDTH     radioOnTics;             // how many tics within the slot the radio is on
    bool                      radioOnThisSlot;         // to control if the radio has been turned on in a slot.
+   
+   // time correction
+   int16_t                   timeCorrection;          // store the timeCorrection, prepend and retrieve it inside of frame header
 } ieee154e_vars_t;
 
 BEGIN_PACK
@@ -247,6 +250,7 @@ void               ieee154e_init(void);
 PORT_RADIOTIMER_WIDTH   ieee154e_asnDiff(asn_t* someASN);
 bool               ieee154e_isSynch(void);
 void               ieee154e_getAsn(uint8_t* array);
+int16_t            ieee154e_getTimeCorrection();
 // events
 void               ieee154e_startOfFrame(PORT_RADIOTIMER_WIDTH capturedTime);
 void               ieee154e_endOfFrame(PORT_RADIOTIMER_WIDTH capturedTime);

--- a/openstack/02a-MAClow/IEEE802154E.h
+++ b/openstack/02a-MAClow/IEEE802154E.h
@@ -250,7 +250,7 @@ void               ieee154e_init(void);
 PORT_RADIOTIMER_WIDTH   ieee154e_asnDiff(asn_t* someASN);
 bool               ieee154e_isSynch(void);
 void               ieee154e_getAsn(uint8_t* array);
-int16_t            ieee154e_getTimeCorrection();
+uint16_t           ieee154e_getTimeCorrection(void);
 // events
 void               ieee154e_startOfFrame(PORT_RADIOTIMER_WIDTH capturedTime);
 void               ieee154e_endOfFrame(PORT_RADIOTIMER_WIDTH capturedTime);

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -469,6 +469,7 @@ functionsToChange = [
     'activity_rie6',
     'activity_ri9',
     'ieee154e_processIEs',
+    'ieee154e_getTimeCorrection',
     'isValidRxFrame',
     'isValidAck',
     'incrementAsnOffset',


### PR DESCRIPTION
Move timeCorrection IE into header.