### PR TITLE
fix GOLDEN_IMAGE ifdef in openserial

### DIFF
--- a/drivers/common/openserial.c
+++ b/drivers/common/openserial.c
@@ -453,7 +453,7 @@ void openserial_goldenImageCommands(void){
    uint8_t  input_buffer[7];
    uint8_t  numDataBytes;
    uint8_t  version;
-#ifndef GOLDEN_IMAGE_NONE
+#ifdef GOLDEN_IMAGE_NONE
    uint8_t  type;
 #endif
    uint8_t  commandId;
@@ -465,7 +465,7 @@ void openserial_goldenImageCommands(void){
    //copying the buffer
    openserial_getInputBuffer(&(input_buffer[0]),numDataBytes);
    version = openserial_vars.inputBuf[1];
-#ifndef GOLDEN_IMAGE_NONE
+#ifdef GOLDEN_IMAGE_NONE
    type    = openserial_vars.inputBuf[2];
 #endif
    if (version != GOLDEN_IMAGE_VERSION) {


### PR DESCRIPTION
Otherwise `type` is not defined in lines 478 and 484.