### PR TITLE
FW-449. Fixing overflow in DAGrank calculation

### DIFF
--- a/openstack/02b-MAChigh/neighbors.c
+++ b/openstack/02b-MAChigh/neighbors.c
@@ -543,7 +543,8 @@ void neighbors_updateMyDAGrankAndNeighborPreference() {
             rankIncrease = (uint16_t)(rankIncreaseIntermediary >> 10);
          }
          
-         tentativeDAGrank = neighbors_vars.neighbors[i].DAGrank+rankIncrease;
+         // cast the uint16_t summands to avoid an overflow if DAGrank == 0xFFFF (MAXDAGRANK)
+         tentativeDAGrank = (uint32_t)neighbors_vars.neighbors[i].DAGrank + (uint32_t)rankIncrease;
          if ( tentativeDAGrank<neighbors_vars.myDAGrank &&
               tentativeDAGrank<MAXDAGRANK) {
             // found better parent, lower my DAGrank


### PR DESCRIPTION
In the calculation of the tentativeDAGrank in
neighbors_updateMyDAGrankAndNeighborPreference an overflow was possible.
This results in occasional choosing a preferred parent with MAXDAGRANK.