### PR TITLE
SW-212. Fix baud rate for IoT-LAB M3 nodes

### DIFF
--- a/bsp/boards/iot-lab_M3/uart.c
+++ b/bsp/boards/iot-lab_M3/uart.c
@@ -53,7 +53,7 @@ void uart_init() {
     GPIO_InitStructure.GPIO_Pin                       = GPIO_Pin_10;
     GPIO_Init(GPIOA, &GPIO_InitStructure);
     
-    USART_InitStructure.USART_BaudRate                = 115200;
+    USART_InitStructure.USART_BaudRate                = 500000;
     USART_InitStructure.USART_WordLength              = USART_WordLength_8b;
     USART_InitStructure.USART_StopBits                = USART_StopBits_1;
     USART_InitStructure.USART_Parity                  = USART_Parity_No;


### PR DESCRIPTION
Fixing the baud rate for the M3 nodes in the IoT-LAB. Has to be 500 kBaud.