### PR TITLE
FW-459. Added a write to radio register at init

### DIFF
--- a/bsp/chips/at86rf231/radio.c
+++ b/bsp/chips/at86rf231/radio.c
@@ -57,6 +57,11 @@ void radio_init() {
    radio_spiWriteReg(RG_ANT_DIV, RADIO_CHIP_ANTENNA);     // use chip antenna
 #define RG_TRX_CTRL_1 0x04
    radio_spiWriteReg(RG_TRX_CTRL_1, 0x20);                // have the radio calculate CRC
+#define INIT_TX_POWER 0x0                                 // potentially set TX_POWER to other than power-on default (0x0)
+                                                          // 0x0 = +3dBm, 0x6 = 0dBm, 0x9 = -3dBm,
+                                                          // 0xC = -7dBm, 0xE = -12dBm, 0xF = -17dBm
+   radio_spiWriteReg(RG_PHY_TX_PWR, (0x3<<6)|INIT_TX_POWER);
+
    //busy wait until radio status is TRX_OFF
   
    while((radio_spiReadReg(RG_TRX_STATUS) & 0x1F) != TRX_OFF);


### PR DESCRIPTION
In bsp/chips/at86tf231/radio.c, added a write to radio register in order to setup TX power at initialization instead of staying with the hardware reset default value.