### PR TITLE
FW-479. unknown RHE are now forwarded by the motes.

### DIFF
--- a/openstack/03a-IPHC/iphc.c
+++ b/openstack/03a-IPHC/iphc.c
@@ -649,7 +649,7 @@ void iphc_retrieveIPv6Header(OpenQueueEntry_t* msg, ipv6_header_iht* ipv6_outer_
     		case ELECTIVE_6LoRH :
     			// this is an elective 6LoRH
     			lorh_length = temp_8b & IPINIP_LEN_6LORH_MASK;
-    			lorh_type = *(uint8_t*)(msg->payload+ipv6_outer_header->header_length+*page_length+extention_header_length);
+    			lorh_type = *(uint8_t*)(msg->payload+ipv6_outer_header->header_length+*page_length+extention_header_length+1);
     			if (lorh_type == IPINIP_TYPE_6LORH){
         			ipv6_outer_header->header_length += 1;
     				// this is IpinIP 6LoRH

--- a/openstack/03a-IPHC/iphc.c
+++ b/openstack/03a-IPHC/iphc.c
@@ -689,7 +689,13 @@ void iphc_retrieveIPv6Header(OpenQueueEntry_t* msg, ipv6_header_iht* ipv6_outer_
     					}
     				}
     			} else {
-    				//unknown elective packet, do not do anything here
+    				//unknown elective packet, print error and skip it
+    				openserial_printError(
+    						COMPONENT_IPHC,
+    				        ERR_6LOWPAN_UNSUPPORTED,
+    				        (errorparameter_t)13,
+    				        (errorparameter_t)(rh3_index)
+    				);
     				extention_header_length += 2 + lorh_length;
     				ipv6_outer_header->rhe_length += 2 + lorh_length;
     			}

--- a/openstack/03a-IPHC/iphc.h
+++ b/openstack/03a-IPHC/iphc.h
@@ -166,6 +166,7 @@ typedef struct {
    uint8_t*    routing_header[MAXNUM_RH3];
    uint8_t*    hopByhop_option;
    uint8_t     hop_limit;
+   uint8_t	   rhe_length;
    open_addr_t src;
    open_addr_t dest;
    uint8_t     header_length;          ///< Counter for internal use

--- a/openstack/03b-IPv6/forwarding.c
+++ b/openstack/03b-IPv6/forwarding.c
@@ -252,8 +252,8 @@ void forwarding_receive(
         &&
         ipv6_outer_header->next_header!=IANA_IPv6ROUTE
     ) {
-        if (ipv6_outer_header->src.type != ADDR_NONE){
-            packetfunctions_tossHeader(msg,ipv6_outer_header->header_length);
+        if (ipv6_outer_header->src.type != ADDR_NONE || ipv6_outer_header->rhe_length){
+            packetfunctions_tossHeader(msg,ipv6_outer_header->header_length + ipv6_outer_header->rhe_length);
         }
         // this packet is for me, no source routing header // toss iphc inner header
         packetfunctions_tossHeader(msg,ipv6_inner_header->header_length);
@@ -453,11 +453,16 @@ owerror_t forwarding_send_internal_SourceRouting(
     uint8_t              flags;
     uint16_t             senderRank;
     
-    uint8_t              RH3_copy[127];
-    uint8_t              RH3_length;
+    uint8_t              RH_copy[127];
+    uint8_t              RH_length;
     
-    memset(&RH3_copy[0],0,127);
+    uint8_t				 RH3_length;
+
+    uint8_t sizeRH=0;
+
+    memset(&RH_copy[0],0,127);
     RH3_length = 0;
+    RH_length = 0;
     memcpy(&msg->l3_destinationAdd,&ipv6_inner_header->dest,sizeof(open_addr_t));
     memcpy(&msg->l3_sourceAdd,&ipv6_inner_header->src,sizeof(open_addr_t));
     
@@ -476,7 +481,18 @@ owerror_t forwarding_send_internal_SourceRouting(
     temp_8b = *((uint8_t*)(msg->payload)+hlen);
     type    = *((uint8_t*)(msg->payload)+hlen+1);
     
+    //copy and toss any unknown 6LoRHE
+    while((temp_8b&FORMAT_6LORH_MASK) == ELECTIVE_6LoRH){
+        sizeRH = temp_8b & IPINIP_LEN_6LORH_MASK;
+    	memcpy(&RH_copy[RH_length], msg->payload, sizeRH+2);
+    	packetfunctions_tossHeader(msg, sizeRH+2);
+    	RH_length += 2 + sizeRH;
+        temp_8b = *((uint8_t*)(msg->payload)+hlen);
+        type    = *((uint8_t*)(msg->payload)+hlen+1);
+    }
+
     hlen += 2;
+
     // get the first address
     switch(type){
     case RH3_6LOTH_TYPE_0:
@@ -658,9 +674,10 @@ owerror_t forwarding_send_internal_SourceRouting(
         ipv6_outer_header->hopByhop_option != NULL
     ){
         // check the length of RH3s
-        RH3_length = ipv6_outer_header->hopByhop_option-msg->payload;
-        memcpy(&RH3_copy[0],msg->payload,RH3_length);
+        RH3_length += ipv6_outer_header->hopByhop_option-msg->payload;
+        memcpy(&RH_copy[RH_length],msg->payload,RH3_length);
         packetfunctions_tossHeader(msg,RH3_length);
+        RH_length += RH3_length;
         
         // retrieve hop-by-hop header (includes RPL option)
         rpi_length = iphc_retrieveIPv6HopByHopHeader(
@@ -712,8 +729,8 @@ owerror_t forwarding_send_internal_SourceRouting(
         ipv6_inner_header,
         rpl_option,
         &ipv6_outer_header->flow_label,
-        &RH3_copy[0],
-        RH3_length,
+        &RH_copy[0],
+        RH_length,
         PCKTFORWARD
     );
 }


### PR DESCRIPTION
Placing an unknown RHE between the page dispatch and RH3s caused the motes to crash. This fix should allow them to forward it unchanged.