### PR TITLE
ADM-62 adding ide functionality to scons builder

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -5,6 +5,7 @@ import subprocess
 import platform
 import distutils.sysconfig
 import sconsUtils
+from tools import qtcreator as q
 
 Import('env')
 
@@ -52,9 +53,8 @@ else:
         env.Append(CPPDEFINES    = 'GOLDEN_IMAGE_ROOT')
     else:
         env.Append(CPPDEFINES    = 'GOLDEN_IMAGE_NONE')
-        
 
-if   env['toolchain']=='mspgcc':
+if env['toolchain']=='mspgcc':
     
     if env['board'] not in ['telosb','wsn430v13b','wsn430v14','gina','z1']:
         raise SystemError('toolchain {0} can not be used for board {1}'.format(env['toolchain'],env['board']))
@@ -362,6 +362,12 @@ elif env['toolchain']=='gcc':
 
 else:
     raise SystemError('unexpected toolchain {0}'.format(env['toolchain']))
+
+if env['ide']=='qtcreator':
+    print env['board']
+    q.QtCreatorManager().initialize(env['board'])
+else:
+    print env['ide']
     
     
 #============================ upload over JTAG ================================

--- a/SConstruct
+++ b/SConstruct
@@ -80,7 +80,8 @@ project:
                    board_crypto_engine).
     l2_security   Use hop-by-hop encryption and authentication.
     goldenImage   sniffer, root or none(default)
-    
+    ide           qtcreator
+
     Common variables:
     verbose        Print each complete compile/link command.
                    0 (off), 1 (on)
@@ -136,6 +137,7 @@ command_line_options = {
     'cryptoengine':     ['', 'dummy_crypto_engine', 'firmware_crypto_engine', 'board_crypto_engine'],
     'l2_security':      ['0','1'],
     'goldenImage':      ['none','root','sniffer'],
+    'ide':              ['none','qtcreator']
 }
 
 def validate_option(key, value, env):
@@ -293,6 +295,13 @@ command_line_vars.AddVariables(
         'comma-separated list of user applications',       # help
         '',                                                # default
         validate_apps,                                     # validator
+        None,                                              # converter
+    ),
+    (
+        'ide',                                            # key
+        'qtcreator by now',                               # help
+        command_line_options['ide'][0],                   # default
+        validate_option,                                   # validator
         None,                                              # converter
     ),
 )

--- a/projects/OpenMote-CC2538/cc2538_gdb.gdb
+++ b/projects/OpenMote-CC2538/cc2538_gdb.gdb
@@ -1,0 +1,14 @@
+target remote localhost:2331
+monitor interface JTAG
+monitor endian little
+monitor speed auto
+monitor flash device = CC2538SF53
+monitor flash breakpoints = 1
+monitor flash download = 1
+monitor reset
+load
+monitor reset
+monitor halt
+break main
+continue
+

--- a/tools/qtcreator.py
+++ b/tools/qtcreator.py
@@ -232,7 +232,13 @@ class QtCreatorManager():
          
         print 'Board is "', self.platform
         
-    
+    def initialize(self,pt):
+        self.platform=pt
+        self.change_dir()
+       
+        self.qtcreator_prepare()
+        self.qtcreator_run()
+     
     # Main function
     def start(self,args):
         

--- a/tools/qtcreator.py
+++ b/tools/qtcreator.py
@@ -7,255 +7,242 @@ import getopt
 
 from distutils.spawn import find_executable
 
-current_dir = "."
-home_dir = ".."
+class QtCreatorManager(): 
 
-ignore_folders = ['.git', 'build', 'tools', 'docs', 'site_scons']
-
-src_extensions = ['.c', '.cpp', '.h', '.hpp', '.py', '.env']
-hdr_extensions = ['.h', '.hpp']
-
-platform_dir = ''
-common_platform_dir = ''
-board_dir = ''
-bootloader_dir = ''
-projects_dir = ''
-common_projects_dir = ''
-bootloader_platform = ''
-projects_platform = ''
-drivers_dir = ''
-drivers_platform = ''
-common_drivers_dir = ''
-drivers_dir = ''
-drivers_platform = ''
-    
-
-
-qtcreator_bin = "qtcreator"
-qtcreator_project = "tools/qtcreator"
-qtcreator_creator = "OpenWSN.creator"
-qtcreator_files = "OpenWSN.files"
-qtcreator_includes = "OpenWSN.includes"
-qtcreator_default = ["-noload", "Welcome", "-noload", "QmlDesigner", "-noload", "QmlProfiler"]
-
-platform = "OpenMote-CC2538"
-# platform = "gina"
- 
-# Determines valid folders
-def is_valid_folder(path):
-    result = False
-
-    if path not in ignore_folders:
-        result = True
-
-    return result
-
-# Returns all folders in the current path
-def get_all_folders(path):
-    result = []
-    folders = next(os.walk(path))
-
-    for f in folders[1]:
-        if is_valid_folder(f):
-            f = os.path.abspath(f)
-            result.append(f)
-    return result
-
-# Determines if it is a valid source file
-def is_valid_source_file(path):
-    name, extension = os.path.splitext(path)
-    if extension in src_extensions:
-        return True
-    return False
-    
-# Determines if it is a valid header directory
-def is_valid_header_dir(path):
-    name, extension = os.path.splitext(path)
-    if extension in hdr_extensions:
-        return True
-    return False
-
-# Gets all files from a path
-def get_all_files(path):
-    global board_dir, bootloader_dir, projects_dir, common_platform_dir, platform_dir, bootloader_dir, bootloader_platform, projects_platform
-    global common_drivers_dir, drivers_dir, drivers_platform
-    
-    result = []
-    boardfolder = False
-    bootloaderfolder = False
-    projectsfolder = False
-    driverfolder = False
-               
-    for path, subdirs, files in os.walk(path):
-        if board_dir in path:
-            boardfolder = True
-        else:
-            boardfolder = False
-       
-        if bootloader_dir in path:
-            bootloaderfolder = True
-        else:
-            bootloaderfolder = False
+    def __init__(self):
         
-        if projects_dir in path:
-            projectsfolder = True
-        else:
-            projectsfolder = False
+        self.current_dir = "."
+        self.home_dir = ".."
         
-        if drivers_dir in path:
-            driverfolder = True
-        else:
-            driverfolder = False
-                
-        for f in files:
-            if is_valid_source_file(f):
-                if (boardfolder and (platform_dir in path or path == common_platform_dir or path == board_dir)): 
-                    r = os.path.join(path, f)
-                    r = os.path.abspath(r)
-                    result.append(r)
-                # bootloader    
-                if (bootloaderfolder and path == bootloader_platform):
-                    r = os.path.join(path, f)
-                    r = os.path.abspath(r)
-                    result.append(r)
-                
-                if (projectsfolder and (projects_platform in path or common_projects_dir in path)):
-                    r = os.path.join(path, f)
-                    r = os.path.abspath(r)
-                    result.append(r)
-                    
-                if (driverfolder and (drivers_platform in path or common_drivers_dir in path)):
-                    r = os.path.join(path, f)
-                    r = os.path.abspath(r)
-                    result.append(r)
-         
-                if (not boardfolder and not bootloaderfolder and not projectsfolder and not driverfolder):
-                    r = os.path.join(path, f)
-                    r = os.path.abspath(r)
-                    result.append(r)
-                    
-                   
+        self.ignore_folders = ['.git', 'build', 'tools', 'docs', 'site_scons']
+        
+        self.src_extensions = ['.c', '.cpp', '.h', '.hpp', '.py', '.env']
+        self.hdr_extensions = ['.h', '.hpp']
+        
+        self.platform_dir = ''
+        self.common_platform_dir = ''
+        self.board_dir = ''
+        self.bootloader_dir = ''
+        self.projects_dir = ''
+        self.common_projects_dir = ''
+        self.bootloader_platform = ''
+        self.projects_platform = ''
+        self.drivers_dir = ''
+        self.drivers_platform = ''
+        self.common_drivers_dir = ''
+        self.drivers_dir = ''
+        self.drivers_platform = ''
+            
+        self.qtcreator_bin = "qtcreator"
+        self.qtcreator_project = "tools/qtcreator"
+        self.qtcreator_creator = "OpenWSN.creator"
+        self.qtcreator_files = "OpenWSN.files"
+        self.qtcreator_includes = "OpenWSN.includes"
+        self.qtcreator_default = ["-noload", "Welcome", "-noload", "QmlDesigner", "-noload", "QmlProfiler"]
+        
+        self.platform = "OpenMote-CC2538"
+        
     
-    return result
-
-# Gets source files from a path
-def get_src_files(path):
-    src_files = []
-    
-    dirs = get_all_folders(path)
-    
-    for d in dirs:
-        files = get_all_files(d)
-        for f in files:
-            if (f):
-                src_files.append(f)
-    src_files.sort()
-    return src_files
-
-# Gets includes folders from a path
-def get_inc_dirs(path):
-    inc_dirs = []
-    
-    dirs = get_all_folders(path)
-
-    for d in dirs:
-        files = get_all_files(d)
-        for f in files:
-            if (f):
-                d, f = os.path.split(f)
-                if d not in inc_dirs:
-                    inc_dirs.append(d)
-    inc_dirs.sort()
-    return inc_dirs
-
-# Writes output to file
-def write_qtcreator(file_name, inc_dirs):
-    fn = open(file_name, 'w')
-    for inc_dir in inc_dirs:
-        fn.write(inc_dir + "\n")
-    fn.close()
-
-# Prepares the QtCreator files
-def qtcreator_prepare():
-    global current_dir
-    
-    print("Preparing QtCreator...")
-    inc_dirs = get_inc_dirs(current_dir)
-    src_files = get_src_files(current_dir)
-    
-    path = os.path.join(qtcreator_project, qtcreator_files)
-    write_qtcreator(path, src_files)    
-    
-    path = os.path.join(qtcreator_project, qtcreator_includes)
-    write_qtcreator(path, inc_dirs)
-
-    print("ok!")
-
-# Runs QtCreator
-def qtcreator_run():
-    qt = [qtcreator_bin, qtcreator_project] + qtcreator_default
-    
-    if (find_executable(qtcreator_bin)):
-        print("Running QtCreator..."),
-        proc = subprocess.Popen(qt, shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        print("ok!")
-    else:
-        print("Error: QtCreator not found!")
-
-# Go to the home project directory
-def change_dir():
-    global current_dir, board_dir, platform_dir, common_platform_dir, bootloader_dir, projects_dir, common_projects_dir, bootloader_platform, projects_platform
-    global common_drivers_dir, drivers_dir, drivers_platform
-    
-    current_dir = os.path.realpath(__file__)
-    d, f = os.path.split(current_dir)
-    home = os.path.join(d, home_dir)
-    os.chdir(home)
-    current_dir = os.path.realpath(home)
-    
-    board_dir = os.path.join(current_dir, 'bsp', 'boards')
-    platform_dir = os.path.join(board_dir, platform)
-    common_platform_dir = os.path.join(board_dir, 'common')
-    
-    bootloader_platform = os.path.join(current_dir, 'bootloader', platform)
-    bootloader_dir = os.path.join(current_dir, 'bootloader')
-    
-    projects_dir = os.path.join(current_dir, 'projects')
-    projects_platform = os.path.join(current_dir, 'projects', platform)
-    common_projects_dir = os.path.join(current_dir, 'projects', 'common')
-    
-    common_drivers_dir = os.path.join(current_dir, 'drivers', 'common')
-    drivers_dir = os.path.join(current_dir, 'drivers')
-    drivers_platform = os.path.join(current_dir, 'drivers', platform)
-    
-
-def parseParams(args):
-    global platform
-    try:
-        opts, args = getopt.getopt(args, "b:", ["board="])
-    except getopt.GetoptError as err:
-        print err
-        print 'Wrong params. Use: qtcreator.py -b <board name>'
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt == '-h':
-           print 'qtcreator.py -b <board name>'
-           sys.exit()
-        elif opt in ("-b", "--board"):
-           platform = arg
      
-    print 'Board is "', platform
+    # Determines valid folders
+    def is_valid_folder(self,path):
+        result = False
     
-
-# Main function
-def main(args):
+        if path not in self.ignore_folders:
+            result = True
     
-    parseParams(args)
+        return result
     
-    change_dir()
-   
-    qtcreator_prepare()
-    qtcreator_run()
-
+    # Returns all folders in the current path
+    def get_all_folders(self,path):
+        result = []
+        folders = next(os.walk(path))
+    
+        for f in folders[1]:
+            if self.is_valid_folder(f):
+                f = os.path.abspath(f)
+                result.append(f)
+        return result
+    
+    # Determines if it is a valid source file
+    def is_valid_source_file(self,path):
+        name, extension = os.path.splitext(path)
+        if extension in self.src_extensions:
+            return True
+        return False
+        
+    # Determines if it is a valid header directory
+    def is_valid_header_dir(self,path):
+        name, extension = os.path.splitext(path)
+        if extension in hdr_extensions:
+            return True
+        return False
+    
+    # Gets all files from a path
+    def get_all_files(self,path):
+        
+        result = []
+        boardfolder = False
+        bootloaderfolder = False
+        projectsfolder = False
+        driverfolder = False
+                   
+        for path, subdirs, files in os.walk(path):
+            if self.board_dir in path:
+                boardfolder = True
+            else:
+                boardfolder = False
+           
+            if self.bootloader_dir in path:
+                bootloaderfolder = True
+            else:
+                bootloaderfolder = False
+            
+            if self.projects_dir in path:
+                projectsfolder = True
+            else:
+                projectsfolder = False
+            
+            if self.drivers_dir in path:
+                driverfolder = True
+            else:
+                driverfolder = False
+                    
+            for f in files:
+                if self.is_valid_source_file(f):
+                    
+                    if ((boardfolder and (self.platform_dir in path or path == self.common_platform_dir or path == self.board_dir))
+                        or ((bootloaderfolder and path == self.bootloader_platform))
+                        or (projectsfolder and (self.projects_platform in path or self.common_projects_dir in path))
+                        or (driverfolder and (self.drivers_platform in path or self.common_drivers_dir in path))):
+                         
+                        r = os.path.join(path, f)
+                        r = os.path.abspath(r)
+                        result.append(r)
+                  
+                    if (not boardfolder and not bootloaderfolder and not projectsfolder and not driverfolder):
+                        r = os.path.join(path, f)
+                        r = os.path.abspath(r)
+                        result.append(r)
+                        
+        return result
+    
+    # Gets source files from a path
+    def get_src_files(self,path):
+        src_files = []
+        
+        dirs = self.get_all_folders(path)
+        
+        for d in dirs:
+            files = self.get_all_files(d)
+            for f in files:
+                if (f):
+                    src_files.append(f)
+        src_files.sort()
+        return src_files
+    
+    # Gets includes folders from a path
+    def get_inc_dirs(self,path):
+        inc_dirs = []
+        
+        dirs = self.get_all_folders(path)
+    
+        for d in dirs:
+            files = self.get_all_files(d)
+            for f in files:
+                if (f):
+                    d, f = os.path.split(f)
+                    if d not in inc_dirs:
+                        inc_dirs.append(d)
+        inc_dirs.sort()
+        return inc_dirs
+    
+    # Writes output to file
+    def write_qtcreator(self,file_name, inc_dirs):
+        fn = open(file_name, 'w')
+        for inc_dir in inc_dirs:
+            fn.write(inc_dir + "\n")
+        fn.close()
+    
+    # Prepares the QtCreator files
+    def qtcreator_prepare(self):
+        
+        print("Preparing QtCreator...")
+        inc_dirs = self.get_inc_dirs(self.current_dir)
+        src_files = self.get_src_files(self.current_dir)
+        
+        path = os.path.join(self.qtcreator_project, self.qtcreator_files)
+        self.write_qtcreator(path, src_files)    
+        
+        path = os.path.join(self.qtcreator_project, self.qtcreator_includes)
+        self.write_qtcreator(path, inc_dirs)
+    
+        print("ok!")
+    
+    # Runs QtCreator
+    def qtcreator_run(self):
+        qt = [self.qtcreator_bin, self.qtcreator_project] + self.qtcreator_default
+        
+        if (find_executable(self.qtcreator_bin)):
+            print("Running QtCreator..."),
+            proc = subprocess.Popen(qt, shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            print("ok!")
+        else:
+            print("Error: QtCreator not found!")
+    
+    # Go to the home project directory
+    def change_dir(self):
+        
+        self.current_dir = os.path.realpath(__file__)
+        d, f = os.path.split(self.current_dir)
+        home = os.path.join(d, self.home_dir)
+        os.chdir(home)
+        self.current_dir = os.path.realpath(home)
+        
+        self.board_dir = os.path.join(self.current_dir, 'bsp', 'boards')
+        self.platform_dir = os.path.join(self.board_dir, self.platform)
+        self.common_platform_dir = os.path.join(self.board_dir, 'common')
+        
+        self.bootloader_platform = os.path.join(self.current_dir, 'bootloader', self.platform)
+        self.bootloader_dir = os.path.join(self.current_dir, 'bootloader')
+        
+        self.projects_dir = os.path.join(self.current_dir, 'projects')
+        self.projects_platform = os.path.join(self.current_dir, 'projects', self.platform)
+        self.common_projects_dir = os.path.join(self.current_dir, 'projects', 'common')
+        
+        self.common_drivers_dir = os.path.join(self.current_dir, 'drivers', 'common')
+        self.drivers_dir = os.path.join(self.current_dir, 'drivers')
+        self.drivers_platform = os.path.join(self.current_dir, 'drivers', self.platform)
+        
+    
+    def parseParams(self,args):
+        global platform
+        try:
+            opts, args = getopt.getopt(args, "b:", ["board="])
+        except getopt.GetoptError as err:
+            print err
+            print 'Wrong params. Use: qtcreator.py -b <board name>'
+            sys.exit(2)
+        for opt, arg in opts:
+            if opt == '-h':
+               print 'qtcreator.py -b <board name>'
+               sys.exit()
+            elif opt in ("-b", "--board"):
+               platform = arg
+         
+        print 'Board is "', self.platform
+        
+    
+    # Main function
+    def start(self,args):
+        
+        self.parseParams(args)
+        
+        self.change_dir()
+       
+        self.qtcreator_prepare()
+        self.qtcreator_run()
+    
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    qtcreator = QtCreatorManager()
+    qtcreator.start(sys.argv[1:])

--- a/tools/qtcreator.py
+++ b/tools/qtcreator.py
@@ -1,0 +1,261 @@
+#!/usr/bin/python
+
+import os
+import subprocess
+import sys
+import getopt
+
+from distutils.spawn import find_executable
+
+current_dir = "."
+home_dir = ".."
+
+ignore_folders = ['.git', 'build', 'tools', 'docs', 'site_scons']
+
+src_extensions = ['.c', '.cpp', '.h', '.hpp', '.py', '.env']
+hdr_extensions = ['.h', '.hpp']
+
+platform_dir = ''
+common_platform_dir = ''
+board_dir = ''
+bootloader_dir = ''
+projects_dir = ''
+common_projects_dir = ''
+bootloader_platform = ''
+projects_platform = ''
+drivers_dir = ''
+drivers_platform = ''
+common_drivers_dir = ''
+drivers_dir = ''
+drivers_platform = ''
+    
+
+
+qtcreator_bin = "qtcreator"
+qtcreator_project = "tools/qtcreator"
+qtcreator_creator = "OpenWSN.creator"
+qtcreator_files = "OpenWSN.files"
+qtcreator_includes = "OpenWSN.includes"
+qtcreator_default = ["-noload", "Welcome", "-noload", "QmlDesigner", "-noload", "QmlProfiler"]
+
+platform = "OpenMote-CC2538"
+# platform = "gina"
+ 
+# Determines valid folders
+def is_valid_folder(path):
+    result = False
+
+    if path not in ignore_folders:
+        result = True
+
+    return result
+
+# Returns all folders in the current path
+def get_all_folders(path):
+    result = []
+    folders = next(os.walk(path))
+
+    for f in folders[1]:
+        if is_valid_folder(f):
+            f = os.path.abspath(f)
+            result.append(f)
+    return result
+
+# Determines if it is a valid source file
+def is_valid_source_file(path):
+    name, extension = os.path.splitext(path)
+    if extension in src_extensions:
+        return True
+    return False
+    
+# Determines if it is a valid header directory
+def is_valid_header_dir(path):
+    name, extension = os.path.splitext(path)
+    if extension in hdr_extensions:
+        return True
+    return False
+
+# Gets all files from a path
+def get_all_files(path):
+    global board_dir, bootloader_dir, projects_dir, common_platform_dir, platform_dir, bootloader_dir, bootloader_platform, projects_platform
+    global common_drivers_dir, drivers_dir, drivers_platform
+    
+    result = []
+    boardfolder = False
+    bootloaderfolder = False
+    projectsfolder = False
+    driverfolder = False
+               
+    for path, subdirs, files in os.walk(path):
+        if board_dir in path:
+            boardfolder = True
+        else:
+            boardfolder = False
+       
+        if bootloader_dir in path:
+            bootloaderfolder = True
+        else:
+            bootloaderfolder = False
+        
+        if projects_dir in path:
+            projectsfolder = True
+        else:
+            projectsfolder = False
+        
+        if drivers_dir in path:
+            driverfolder = True
+        else:
+            driverfolder = False
+                
+        for f in files:
+            if is_valid_source_file(f):
+                if (boardfolder and (platform_dir in path or path == common_platform_dir or path == board_dir)): 
+                    r = os.path.join(path, f)
+                    r = os.path.abspath(r)
+                    result.append(r)
+                # bootloader    
+                if (bootloaderfolder and path == bootloader_platform):
+                    r = os.path.join(path, f)
+                    r = os.path.abspath(r)
+                    result.append(r)
+                
+                if (projectsfolder and (projects_platform in path or common_projects_dir in path)):
+                    r = os.path.join(path, f)
+                    r = os.path.abspath(r)
+                    result.append(r)
+                    
+                if (driverfolder and (drivers_platform in path or common_drivers_dir in path)):
+                    r = os.path.join(path, f)
+                    r = os.path.abspath(r)
+                    result.append(r)
+         
+                if (not boardfolder and not bootloaderfolder and not projectsfolder and not driverfolder):
+                    r = os.path.join(path, f)
+                    r = os.path.abspath(r)
+                    result.append(r)
+                    
+                   
+    
+    return result
+
+# Gets source files from a path
+def get_src_files(path):
+    src_files = []
+    
+    dirs = get_all_folders(path)
+    
+    for d in dirs:
+        files = get_all_files(d)
+        for f in files:
+            if (f):
+                src_files.append(f)
+    src_files.sort()
+    return src_files
+
+# Gets includes folders from a path
+def get_inc_dirs(path):
+    inc_dirs = []
+    
+    dirs = get_all_folders(path)
+
+    for d in dirs:
+        files = get_all_files(d)
+        for f in files:
+            if (f):
+                d, f = os.path.split(f)
+                if d not in inc_dirs:
+                    inc_dirs.append(d)
+    inc_dirs.sort()
+    return inc_dirs
+
+# Writes output to file
+def write_qtcreator(file_name, inc_dirs):
+    fn = open(file_name, 'w')
+    for inc_dir in inc_dirs:
+        fn.write(inc_dir + "\n")
+    fn.close()
+
+# Prepares the QtCreator files
+def qtcreator_prepare():
+    global current_dir
+    
+    print("Preparing QtCreator...")
+    inc_dirs = get_inc_dirs(current_dir)
+    src_files = get_src_files(current_dir)
+    
+    path = os.path.join(qtcreator_project, qtcreator_files)
+    write_qtcreator(path, src_files)    
+    
+    path = os.path.join(qtcreator_project, qtcreator_includes)
+    write_qtcreator(path, inc_dirs)
+
+    print("ok!")
+
+# Runs QtCreator
+def qtcreator_run():
+    qt = [qtcreator_bin, qtcreator_project] + qtcreator_default
+    
+    if (find_executable(qtcreator_bin)):
+        print("Running QtCreator..."),
+        proc = subprocess.Popen(qt, shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print("ok!")
+    else:
+        print("Error: QtCreator not found!")
+
+# Go to the home project directory
+def change_dir():
+    global current_dir, board_dir, platform_dir, common_platform_dir, bootloader_dir, projects_dir, common_projects_dir, bootloader_platform, projects_platform
+    global common_drivers_dir, drivers_dir, drivers_platform
+    
+    current_dir = os.path.realpath(__file__)
+    d, f = os.path.split(current_dir)
+    home = os.path.join(d, home_dir)
+    os.chdir(home)
+    current_dir = os.path.realpath(home)
+    
+    board_dir = os.path.join(current_dir, 'bsp', 'boards')
+    platform_dir = os.path.join(board_dir, platform)
+    common_platform_dir = os.path.join(board_dir, 'common')
+    
+    bootloader_platform = os.path.join(current_dir, 'bootloader', platform)
+    bootloader_dir = os.path.join(current_dir, 'bootloader')
+    
+    projects_dir = os.path.join(current_dir, 'projects')
+    projects_platform = os.path.join(current_dir, 'projects', platform)
+    common_projects_dir = os.path.join(current_dir, 'projects', 'common')
+    
+    common_drivers_dir = os.path.join(current_dir, 'drivers', 'common')
+    drivers_dir = os.path.join(current_dir, 'drivers')
+    drivers_platform = os.path.join(current_dir, 'drivers', platform)
+    
+
+def parseParams(args):
+    global platform
+    try:
+        opts, args = getopt.getopt(args, "b:", ["board="])
+    except getopt.GetoptError as err:
+        print err
+        print 'Wrong params. Use: qtcreator.py -b <board name>'
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+           print 'qtcreator.py -b <board name>'
+           sys.exit()
+        elif opt in ("-b", "--board"):
+           platform = arg
+     
+    print 'Board is "', platform
+    
+
+# Main function
+def main(args):
+    
+    parseParams(args)
+    
+    change_dir()
+   
+    qtcreator_prepare()
+    qtcreator_run()
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/qtcreator/OpenWSN.config
+++ b/tools/qtcreator/OpenWSN.config
@@ -1,0 +1,2 @@
+// Add predefined macros for your project here. For example:
+// #define THE_ANSWER 42

--- a/tools/qtcreator/OpenWSN.creator
+++ b/tools/qtcreator/OpenWSN.creator
@@ -1,0 +1,1 @@
+[General]

--- a/tools/qtcreator/OpenWSN.creator.user
+++ b/tools/qtcreator/OpenWSN.creator.user
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 3.6.1, 2016-05-20T18:40:48. -->
+<qtcreator>
+ <data>
+  <variable>EnvironmentId</variable>
+  <value type="QByteArray">{904631d7-3e8a-468b-8567-84b671f0480e}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.MarginColumn">80</value>
+   <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap"/>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">scons</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">scons</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{e1c7ba1e-f1b5-4874-9829-f38a8dd74dd0}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">-1</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">openwsn-fw/build</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <valuelist type="QVariantList" key="GenericProjectManager.GenericMakeStep.BuildTargets">
+       <value type="QString">all</value>
+      </valuelist>
+      <value type="bool" key="GenericProjectManager.GenericMakeStep.Clean">false</value>
+      <value type="QString" key="GenericProjectManager.GenericMakeStep.MakeArguments"></value>
+      <value type="QString" key="GenericProjectManager.GenericMakeStep.MakeCommand"></value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">GenericProjectManager.GenericMakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <valuelist type="QVariantList" key="GenericProjectManager.GenericMakeStep.BuildTargets">
+       <value type="QString">clean</value>
+      </valuelist>
+      <value type="bool" key="GenericProjectManager.GenericMakeStep.Clean">true</value>
+      <value type="QString" key="GenericProjectManager.GenericMakeStep.MakeArguments"></value>
+      <value type="QString" key="GenericProjectManager.GenericMakeStep.MakeCommand"></value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">GenericProjectManager.GenericMakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">GenericProjectManager.GenericBuildConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">1</value>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.PluginSettings"/>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Arguments"></value>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.Executable"></value>
+    <value type="QString" key="ProjectExplorer.CustomExecutableRunConfiguration.WorkingDirectory">%{buildDir}</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Custom Executable</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.CustomExecutableRunConfiguration</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.1">
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="QString" key="BareMetal.CustomRunConfig.Executable"></value>
+    <value type="QString" key="BareMetal.RunConfig.WorkingDirectory"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qtcreator (via GDB server or hardware debugger)</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">BareMetal.CustomRunConfig</value>
+    <value type="QString" key="Qt4ProjectManager.MaemoRunConfiguration.Arguments"></value>
+    <value type="QString" key="Qt4ProjectManager.MaemoRunConfiguration.ProFile">.</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">2</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">18</value>
+ </data>
+ <data>
+  <variable>Version</variable>
+  <value type="int">18</value>
+ </data>
+</qtcreator>


### PR DESCRIPTION
this adds a new functionality to scons builder system. By specifying the [ide] e.g., ide=qtcreator the IDE is configured automatically according to the board we are compiling. for example
scons board=OpenMote-CC2538 toolchain=armgcc ide=qtcreator oos_openwsn. 

this runs qtcreator (must be in the path) configured for the openmote platform. We can run it for gina, telosb, etc...

qtcreator is opensource and can be downloaded from here 
http://www.qt.io/download-open-source/

or installed in linux by
sudo apt-get install qtcreator

no need to register, just skip and have fun. it is a lightweight and fast ide with very nice functionalities.
It is tested in windows and linux. Note that qtcreator must be in the path.