### PR TITLE
FW-497. For CoAP, use a NON type response for a NON type request.

### DIFF
--- a/openstack/04-TRAN/opencoap.c
+++ b/openstack/04-TRAN/opencoap.c
@@ -50,6 +50,7 @@ void opencoap_receive(OpenQueueEntry_t* msg) {
    coap_resource_desc_t*     temp_desc;
    bool                      found;
    owerror_t                 outcome = 0;
+   coap_type_t               response_type;
    // local variables passed to the handlers (with msg)
    coap_header_iht           coap_header;
    coap_option_iht           coap_options[MAX_COAP_OPTIONS];
@@ -248,6 +249,12 @@ void opencoap_receive(OpenQueueEntry_t* msg) {
       coap_header.TKL                  = 0;
       coap_header.Code                 = COAP_CODE_RESP_METHODNOTALLOWED;
    }
+
+   if (coap_header.T == COAP_TYPE_CON) {
+       response_type = COAP_TYPE_ACK;
+   } else {
+       response_type = COAP_TYPE_NON;
+   }
    
    //=== step 4. send that packet back
    
@@ -269,7 +276,7 @@ void opencoap_receive(OpenQueueEntry_t* msg) {
    // fill in CoAP header
    packetfunctions_reserveHeaderSize(msg,4+coap_header.TKL);
    msg->payload[0]                  = (COAP_VERSION    << 6) |
-                                      (COAP_TYPE_ACK   << 4) |
+                                      (response_type   << 4) |
                                       (coap_header.TKL << 0);
    msg->payload[1]                  = coap_header.Code;
    msg->payload[2]                  = coap_header.messageID/256;


### PR DESCRIPTION
* Use an ACK response only for a CON request.