### PR TITLE
FW-577. Set the PANID at compilation time.

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -35,7 +35,8 @@ dummyFunc = Builder(
     action = '',
     suffix = '.ihex',
 )
-
+if env['panid']:
+    env.Append(CPPDEFINES    = {'PANID_DEFINED' : env['panid']})
 if env['dagroot']==1:
     env.Append(CPPDEFINES    = 'DAGROOT')
 if env['forcetopology']==1:

--- a/SConstruct
+++ b/SConstruct
@@ -129,6 +129,7 @@ command_line_options = {
     'fastsim':          ['1','0'],
     'simhost':          ['amd64-linux','x86-linux','amd64-windows','x86-windows'],
     'simhostpy':        [''],                               # No reasonable default
+    'panid':            [''],
     'dagroot':          ['0','1'],
     'forcetopology':    ['0','1'],
     'debug':            ['0','1'],
@@ -235,6 +236,13 @@ command_line_vars.AddVariables(
         'simhostpy',                                       # key
         '',                                                # help
         command_line_options['simhostpy'][0],              # default
+        None,                                              # validator
+        None,                                              # converter
+    ),
+    (
+        'panid',                                           # key
+        '0xFFFF',                                          # help
+        command_line_options['panid'][0],                  # default
         None,                                              # validator
         None,                                              # converter
     ),

--- a/openstack/cross-layers/idmanager.c
+++ b/openstack/cross-layers/idmanager.c
@@ -32,7 +32,13 @@ void idmanager_init() {
    idmanager_vars.myPANID.type         = ADDR_PANID;
    idmanager_vars.myPANID.panid[0]     = 0xca;
    idmanager_vars.myPANID.panid[1]     = 0xfe;
-   
+#ifdef PANID_DEFINED 
+   idmanager_vars.myPANID.panid[0]     = PANID_DEFINED & 0x00ff;
+   idmanager_vars.myPANID.panid[1]     =(PANID_DEFINED & 0xff00)>>8;
+#else
+   idmanager_vars.myPANID.panid[0]     = 0xca;
+   idmanager_vars.myPANID.panid[1]     = 0xfe;
+#endif
    // myPrefix
    idmanager_vars.myPrefix.type        = ADDR_PREFIX;
 #ifdef DAGROOT


### PR DESCRIPTION
================= example  ======================================
C:\Users\in\Desktop\work\openwsn-fw>scons board=python panid=0x2FD8 toolchain=gc
c oos_openwsn
scons: Reading SConscript files ...

 __            __     _ _ _  ___  _ _
| .\ ___      |  |   | | | |/ __>| \ |
|   || . \    _| |   | | | |\__ \|   |
`__/'|  _/  \____/   |__/_/ <___/|_\_|
     |_|\_\                openwsn.org

none
scons: done reading SConscript files.
scons: Building targets ...
Compiling (shared) build\python_gcc\projects\common\03oos_openwsn\03oos_openwsn_
obj.o
.................
.................
.................
Compiling          build\python_gcc\bsp\boards\common\dummy_crypto_engine.o
gcc -shared -o build\python_gcc\projects\common\oos_openwsn.pyd build\python_gcc
\projects\common\03oos_openwsn\03oos_openwsn_obj.o build\python_gcc\projects\com
mon\03oos_openwsn\openwsnmodule_obj.o -LC:\Python27\libs -Lbuild\python_gcc\bsp\
boards -Lbuild\python_gcc\kernel\openos -Lbuild\python_gcc\drivers -Lbuild\pytho
n_gcc\openstack -Lbuild\python_gcc\openapps -lopenstack -lopenapps -lkernel -ldr
ivers -lbsp -lpython27 -Wl,--out-implib,build\python_gcc\projects\common\liboos_
openwsn.a
scons: done building targets.