### PR TITLE
No radio retune needed for ACK send/receive

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -193,7 +193,7 @@ elif env['toolchain']=='iar-proj':
     
 elif env['toolchain']=='armgcc':
     
-    if env['board'] not in ['OpenMote-CC2538','iot-lab_M3','iot-lab_A8-M3','openmotestm']:
+    if env['board'] not in ['OpenMote-CC2538','iot-lab_M3','iot-lab_A8-M3','openmotestm', 'samr21_xpro']:
         raise SystemError('toolchain {0} can not be used for board {1}'.format(env['toolchain'],env['board']))
     
     if   env['board']=='OpenMote-CC2538':
@@ -272,6 +272,46 @@ elif env['toolchain']=='armgcc':
         env.Append(LINKFLAGS     = '-Tbsp/boards/'+env['board']+'/stm32_flash.ld')
         env.Append(LINKFLAGS     = os.path.join('build',env['board']+'_armgcc','bsp','boards',env['board'],'startup.o'))
         env.Append(LINKFLAGS     = os.path.join('build',env['board']+'_armgcc','bsp','boards',env['board'],'configure','stm32f10x_it.o'))
+        # object manipulation
+        env.Replace(OBJCOPY      = 'arm-none-eabi-objcopy')
+        env.Replace(OBJDUMP      = 'arm-none-eabi-objdump')
+        # archiver
+        env.Replace(AR           = 'arm-none-eabi-ar')
+        env.Append(ARFLAGS       = '')
+        env.Replace(RANLIB       = 'arm-none-eabi-ranlib')
+        env.Append(RANLIBFLAGS   = '')
+        # misc
+        env.Replace(NM           = 'arm-none-eabi-nm')
+        env.Replace(SIZE         = 'arm-none-eabi-size')
+        
+    elif   env['board'] in ['samr21_xpro']:
+        
+        # compiler (C)
+        env.Replace(CC           = 'arm-none-eabi-gcc')
+        env.Append(CCFLAGS       = '-O1')
+        env.Append(CCFLAGS       = '-Wall')
+        env.Append(CCFLAGS       = '-Wa,-adhlns=${TARGET.base}.lst')
+        env.Append(CCFLAGS       = '-c')
+        env.Append(CCFLAGS       = '-fmessage-length=0')
+        env.Append(CCFLAGS       = '-mcpu=cortex-m0plus')
+        env.Append(CCFLAGS       = '-mthumb')
+        env.Append(CCFLAGS       = '-g3')
+        env.Append(CCFLAGS       = '-Wstrict-prototypes')
+        env.Append(CCFLAGS       = '-Ibsp/boards/samr21_xpro/drivers/inc')
+        env.Append(CCFLAGS       = '-Ibsp/boards/samr21_xpro/cmsis/inc')
+        env.Append(CCFLAGS       = '-D__SAMR21G18A__')
+        env.Append(CCFLAGS       = '-Ibsp/boards/samr21_xpro/SAMR21_DFP/1.0.34/include')
+        # assembler
+        env.Replace(AS           = 'arm-none-eabi-as')
+        env.Append(ASFLAGS       = '-ggdb -g3 -mcpu=cortex-m0plus -mlittle-endian')
+        # linker
+        env.Append(LINKFLAGS     = '-Tbsp/boards/samr21_xpro/cmsis/linkerScripts/samr21g18a_flash.ld')
+#        env.Append(LINKFLAGS     = '-Tbsp/boards/samr21_xpro/cmsis/linkerScripts/samr21g18a_sram.ld')
+        env.Append(LINKFLAGS     = '-nostartfiles')
+        env.Append(LINKFLAGS     = '-Wl,-Map,${TARGET.base}.map')
+        env.Append(LINKFLAGS     = '-mcpu=cortex-m0plus')
+        env.Append(LINKFLAGS     = '-mthumb')
+        env.Append(LINKFLAGS     = '-g3')
         # object manipulation
         env.Replace(OBJCOPY      = 'arm-none-eabi-objcopy')
         env.Replace(OBJDUMP      = 'arm-none-eabi-objdump')

--- a/SConstruct
+++ b/SConstruct
@@ -110,6 +110,7 @@ command_line_options = {
         'iot-lab_M3',
         'iot-lab_A8-M3',
         'agilefox',
+        'samr21_xpro',
         # misc.
         'python',
     ],

--- a/bsp/boards/samr21_xpro/SConscript
+++ b/bsp/boards/samr21_xpro/SConscript
@@ -4,4 +4,44 @@ Import('env')
 
 localEnv = env.Clone()
 
+# scons doesn't let us look to parent directories for source, so the
+# bsp/chips/at86rf231/radio.c is off limits from this file. To keep things
+# simple, each SConscript file in bsp/chips/* will return a list of objects
+# which can be appended to the source list. Don't forget to specify a variant_dir,
+# or else the build will occur directly in the chips directory.
 
+rf231 = localEnv.SConscript(
+    os.path.join('#','bsp','chips','at86rf231','SConscript'),
+    variant_dir = 'rf231',
+    exports     = {'env': env},
+)
+
+source = [
+    'board.c',
+    'bsp_timer.c',
+    'debug_pins.c',
+    'eui64.c',
+    'flash.c',
+    'gpio.c',
+    'leds.c',
+    'radio_timer.c',
+    'spi_drv.c',
+    'uart.c',
+    'drivers/src/cm0_handler.c',
+    'drivers/src/cm0plus_interrupt.c',
+    'drivers/src/samr21_extint.c',
+    'drivers/src/samr21_flash.c',
+    'drivers/src/samr21_gclk.c',
+    'drivers/src/samr21_gpio.c',
+    'drivers/src/samr21_spi.c',
+    'drivers/src/samr21_sysctrl.c',
+    'drivers/src/samr21_timer.c',
+    'drivers/src/samr21_uart.c',
+    'cmsis/src/startup_samr21.c',
+    'cmsis/src/system_samr21.c',
+]
+
+
+board  = localEnv.Object(source=source) + rf231
+
+Return('board')

--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -1169,12 +1169,6 @@ port_INLINE void activity_ti6() {
    // change state
    changeState(S_RXACKPREPARE);
    
-   // calculate the frequency to transmit on
-   ieee154e_vars.freq = calculateFrequency(schedule_getChannelOffset()); 
-   
-   // configure the radio for that frequency
-   radio_setFrequency(ieee154e_vars.freq);
-   
    // enable the radio in Rx mode. The radio is not actively listening yet.
    radio_rxEnable();
    //caputre init of radio for duty cycle calculation
@@ -1664,12 +1658,6 @@ port_INLINE void activity_ri6() {
     // space for 2-byte CRC
    packetfunctions_reserveFooterSize(ieee154e_vars.ackToSend,2);
   
-    // calculate the frequency to transmit on
-   ieee154e_vars.freq = calculateFrequency(schedule_getChannelOffset()); 
-   
-   // configure the radio for that frequency
-   radio_setFrequency(ieee154e_vars.freq);
-   
    // load the packet in the radio's Tx buffer
    radio_loadPacket(ieee154e_vars.ackToSend->payload,
                     ieee154e_vars.ackToSend->length);


### PR DESCRIPTION
With 2 nodes side-by-side on the bench (so good radio reception), I was seeing ACKs occasionally not being picked up when frequency-hopping, but not when running single-frequency.  With the radio-retune lines of code deleted from activity_ti6() and activity_ri6(), 100% of ACKs are received.