### PR TITLE
correct comments that has some typos

### DIFF
--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -761,7 +761,7 @@ port_INLINE bool ieee154e_processIEs(OpenQueueEntry_t* pkt, uint16_t* lenIE) {
                
                case IEEE802154E_MLME_TIMESLOT_IE_SUBID:
                   if (idmanager_getIsDAGroot()==FALSE) {
-                      // timelsot template ID
+                      // timeslot template ID
                       timeslotTemplateIDStoreFromEB(*((uint8_t*)(pkt->payload)+ptr));
                       ptr = ptr + 1;
                       if (ieee154e_vars.tsTemplateId != TIMESLOT_TEMPLATE_ID){
@@ -775,7 +775,7 @@ port_INLINE bool ieee154e_processIEs(OpenQueueEntry_t* pkt, uint16_t* lenIE) {
                   
                case IEEE802154E_MLME_CHANNELHOPPING_IE_SUBID:
                   if (idmanager_getIsDAGroot()==FALSE) {
-                      // timelsot template ID
+                      // channelhopping template ID
                       channelhoppingTemplateIDStoreFromEB(*((uint8_t*)(pkt->payload)+ptr));
                       ptr = ptr + 1;
                   }

--- a/openstack/02b-MAChigh/processIE.c
+++ b/openstack/02b-MAChigh/processIE.c
@@ -230,7 +230,7 @@ port_INLINE uint8_t processIE_prependChannelHoppingIE(OpenQueueEntry_t* pkt){
    
    len = 0;
 
-   // reserve space for timeslot template ID
+   // reserve space for channelhopping template ID
    packetfunctions_reserveHeaderSize(pkt,sizeof(uint8_t));
    // write header
    *((uint8_t*)(pkt->payload)) = CHANNELHOPPING_TEMPLATE_ID;


### PR DESCRIPTION
In IEEE802154e.c and processIE.c, there are some typos related to timeslot template ID and channelhopping template ID at some comments.