### PR TITLE
FW-697. Initialize OSCOAP context just before sending the Join Request.

### DIFF
--- a/openapps/cjoin/cjoin.c
+++ b/openapps/cjoin/cjoin.c
@@ -74,7 +74,6 @@ void cjoin_init() {
    cjoin_vars.timerId = opentimers_create();
 
    idmanager_setJoinKey((uint8_t *) masterSecret);
-   cjoin_init_security_context();
 
    cjoin_schedule();
 }
@@ -191,6 +190,10 @@ void cjoin_task_cb() {
     
     // cancel the startup timer but do not destroy it as we reuse it for retransmissions
     opentimers_cancel(cjoin_vars.timerId);
+
+    // init the security context only here in order to use the latest joinKey
+    // that may be set over the serial
+    cjoin_init_security_context();
 
     cjoin_sendJoinRequest(joinProxy);
 


### PR DESCRIPTION
With this PR, OSCOAP security context is initialized just before sending the Join Request. This fixes the issue of not using the key configured over serial for sending the Join Request.