### PR TITLE
FW-701. Introduce a flag to signal presence of dynamic keying support.

### DIFF
--- a/openapps/cjoin/cjoin.c
+++ b/openapps/cjoin/cjoin.c
@@ -56,6 +56,9 @@ void        cjoin_setIsJoined(bool newValue);
 //=========================== public ==========================================
 
 void cjoin_init() {
+   // declare the usage of dynamic keying to L2 security module
+   IEEE802154_security_setDynamicKeying();
+
    // prepare the resource descriptor for the /j path
    cjoin_vars.desc.path0len                        = sizeof(cjoin_path0)-1;
    cjoin_vars.desc.path0val                        = (uint8_t*)(&cjoin_path0);

--- a/openstack/02a-MAClow/IEEE802154_security.c
+++ b/openstack/02a-MAClow/IEEE802154_security.c
@@ -23,12 +23,17 @@
 ieee802154_security_vars_t ieee802154_security_vars;
 
 //========= common functions regardless of whether L2SEC is used or not =======
-// following 6 functions are also called when L2SEC is not used. This is to facilitate
+// following 7 functions are also called when L2SEC is not used. This is to facilitate
 // automated testing of SECJOIN without L2SEC and to ensure the order in which nodes
 // start sending out EBs. With the current implementation, EBs are sent only once the
 // node has received a Join Response from the JRC.
 
 void IEEE802154_security_init(void) {
+
+   // By default, we assume that no dynamic keying (SEC JOIN) is used
+   // if an app is linked with dynamic keying support, it should set
+   // this flag to true by calling IEEE802154_security_setDynamicKeying()
+   ieee802154_security_vars.dynamicKeying = FALSE;
 
     // TODO joinPermitted flag should be set dynamically upon a button press
     // and propagated through the network via EBs
@@ -61,11 +66,19 @@ void IEEE802154_security_setDataKey(uint8_t index, uint8_t* value) {
 }
 
 bool IEEE802154_security_isConfigured() {
+    if (ieee802154_security_vars.dynamicKeying == FALSE) {
+        return TRUE;
+    }
+
     if (ieee802154_security_vars.k1.index != IEEE802154_SECURITY_KEYINDEX_INVALID &&
          ieee802154_security_vars.k2.index != IEEE802154_SECURITY_KEYINDEX_INVALID) {
         return TRUE;
     }
     return FALSE;
+}
+
+void IEEE802154_security_setDynamicKeying() {
+    ieee802154_security_vars.dynamicKeying = TRUE;
 }
 
 //=========================== public ==========================================

--- a/openstack/02a-MAClow/IEEE802154_security.h
+++ b/openstack/02a-MAClow/IEEE802154_security.h
@@ -52,6 +52,7 @@ typedef struct{
 //=========================== variables =======================================
 
 typedef struct {
+   bool                    dynamicKeying;
    bool                    joinPermitted;
    symmetric_key_802154_t  k1;
    symmetric_key_802154_t  k2;
@@ -73,6 +74,7 @@ void        IEEE802154_security_setDataKey(uint8_t index, uint8_t* value);
 uint8_t     IEEE802154_security_getSecurityLevel(OpenQueueEntry_t *msg);
 bool        IEEE802154_security_acceptableLevel(OpenQueueEntry_t* msg, ieee802154_header_iht* parsedHeader);
 bool        IEEE802154_security_isConfigured(void);
+void        IEEE802154_security_setDynamicKeying(void);
 
 
 /**

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -464,6 +464,7 @@ functionsToChange = [
     'IEEE802154_security_getSecurityLevel',
     'IEEE802154_security_acceptableLevel',
     'IEEE802154_security_isConfigured',
+    'IEEE802154_security_setDynamicKeying',
     # IEEE802154
     'ieee802154_prependHeader',
     'ieee802154_retrieveHeader',


### PR DESCRIPTION
This PR solves the issue of intermediate nodes not sending EBs when cjoin app is not used. 