### PR TITLE
Fix "old-style function definition" warning all over the repo

### DIFF
--- a/bsp/boards/agilefox/board.c
+++ b/bsp/boards/agilefox/board.c
@@ -24,7 +24,7 @@
 
 extern int mote_main();
 
-int main() {
+int main(void) {
    return mote_main();
 }
 
@@ -91,7 +91,7 @@ void board_init()
     NVIC_radio();
 }
 
-void board_sleep() {
+void board_sleep(void) {
     uint16_t sleepTime = radiotimer_getPeriod() - radiotimer_getCapturedTime();
     DBGMCU_Config(DBGMCU_STOP, ENABLE);
     

--- a/bsp/boards/agilefox/debugpins.c
+++ b/bsp/boards/agilefox/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
   
 //    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC , ENABLE);
 //    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA , ENABLE);
@@ -49,67 +49,67 @@ void debugpins_init() {
 }
 
 // PC.5
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
   //GPIOC->ODR ^= 0X0020;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
   //GPIOC->ODR &= ~0X0020;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
   //GPIOC->ODR |=  0X0020;
 }
 
 // PA.7
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
   //GPIOA->ODR ^=  0X0080;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
   //GPIOA->ODR &= ~0X0080;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
   //GPIOA->ODR |=  0X0080;
 }
 
 // PA.5
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
   //GPIOA->ODR ^=  0X0020;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
   //GPIOA->ODR &= ~0X0020;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
   //GPIOA->ODR |=  0X0020;
 }
 
 // PA.6
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
   //GPIOA->ODR ^=  0X0040;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
   //GPIOA->ODR &= ~0X0040;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
   //GPIOA->ODR |= 0X0040;
 }
 
 // PC.1
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
   //GPIOC->ODR ^=  0X0002;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
   //GPIOC->ODR &= ~0X0002;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
   //GPIOC->ODR |= 0X0002;
 }
 
 // PC.0
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
   //GPIOC->ODR ^=  0X0001;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
   //GPIOC->ODR &= ~0X0001;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
   //GPIOC->ODR |=  0X0001;
 }

--- a/bsp/boards/agilefox/leds.c
+++ b/bsp/boards/agilefox/leds.c
@@ -49,7 +49,7 @@ uint8_t leds_error_isOn(){
    }
    return bitstatus;
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
 }
 
 // green

--- a/bsp/boards/agilefox/radiotimer.c
+++ b/bsp/boards/agilefox/radiotimer.c
@@ -41,7 +41,7 @@ radiotimer_vars_t radiotimer_vars;
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
    // clear local variables
    memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
 }
@@ -118,7 +118,7 @@ void radiotimer_start(uint16_t period) {
 
 //===== direct access
 
-uint16_t radiotimer_getValue() {
+uint16_t radiotimer_getValue(void) {
     RTC_WaitForSynchro();
     uint32_t counter = RTC_GetCounter();
     return (uint16_t)counter;
@@ -142,7 +142,7 @@ void radiotimer_setPeriod(uint16_t period) {
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-uint16_t radiotimer_getPeriod() {
+uint16_t radiotimer_getPeriod(void) {
     RTC_WaitForSynchro();
     uint32_t period = RTC_GetAlarm();
     return (uint16_t)period;
@@ -164,7 +164,7 @@ void radiotimer_schedule(uint16_t offset) {
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
     RTC_ITConfig(RTC_IT_ALR, DISABLE);
     //need to disable radio also in case that a radio interrupt is happening
     
@@ -181,7 +181,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-inline uint16_t radiotimer_getCapturedTime() {
+inline uint16_t radiotimer_getCapturedTime(void) {
     RTC_WaitForSynchro();
     uint32_t counter = RTC_GetCounter();
     return (uint16_t)counter;
@@ -191,7 +191,7 @@ inline uint16_t radiotimer_getCapturedTime() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t radiotimer_isr() {
+kick_scheduler_t radiotimer_isr(void) {
    uint8_t taiv_temp = radiotimer_vars.overflowORcompare;
    switch (taiv_temp) {
       case RADIOTIMER_COMPARE:

--- a/bsp/boards/agilefox/rtc_timer.c
+++ b/bsp/boards/agilefox/rtc_timer.c
@@ -26,7 +26,7 @@ rtc_timer_vars_t rtc_timer_vars;
 
 //===== admin
 
-void rtc_timer_init() {
+void rtc_timer_init(void) {
    // clear local variables
    memset(&rtc_timer_vars,0,sizeof(rtc_timer_vars_t));
 }
@@ -95,12 +95,12 @@ void rtc_timer_start(u32 alarmValue)
 
 //===== direct access
 
-uint16_t rtc_timer_getAlarm() {
+uint16_t rtc_timer_getAlarm(void) {
     uint32_t alarmValue = RTC_GetAlarm();
     return (uint16_t)alarmValue;
 }
 
-void    rtc_timer_resetCounter() {
+void    rtc_timer_resetCounter(void) {
     RTC_SetCounter(0);                //Set RTC Counter to begin a new slot
     RTC_WaitForLastTask();            //Wait until last write operation on RTC registers has finished
 }

--- a/bsp/boards/agilefox/spi.c
+++ b/bsp/boards/agilefox/spi.c
@@ -49,7 +49,7 @@ inline static void SLEEP_CLR(void) { GPIOA->BRR = 1<<0; }
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
     memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -208,7 +208,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/cc1200dk/board.c
+++ b/bsp/boards/cc1200dk/board.c
@@ -30,7 +30,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    
     uint16_t ui16IntState;
     // Stop watchdog timer (prevent timeout reset)
@@ -55,11 +55,11 @@ void board_init() {
     __bis_SR_register(GIE);
 }
 
-void board_sleep() {
+void board_sleep(void) {
     __bis_SR_register(GIE+LPM3_bits);             // sleep, but leave ACLK on
 }
 
-void board_reset() {
+void board_reset(void) {
     WDTCTL = (WDTPW+0x1200) + WDTHOLD; // writing a wrong watchdog password to causes handler to reset
 }
 

--- a/bsp/boards/cc1200dk/bsp_timer.c
+++ b/bsp/boards/cc1200dk/bsp_timer.c
@@ -31,7 +31,7 @@ void bsp_timer_isr_private(void);
 This functions starts the timer, i.e. the counter increments, but doesn't set
 any compare registers, so no interrupt will fire.
 */
-void bsp_timer_init() {
+void bsp_timer_init(void) {
    
     // clear local variables
     memset(&bsp_timer_vars,0,sizeof(bsp_timer_vars_t));
@@ -55,7 +55,7 @@ void bsp_timer_set_callback(bsp_timer_cbt cb) {
 This function does not stop the timer, it rather resets the value of the
 counter, and cancels a possible pending compare event.
 */
-void bsp_timer_reset() {
+void bsp_timer_reset(void) {
     // reset compare
     TA0CCR0                =  0;
     TA0CCTL0               =  0;
@@ -105,7 +105,7 @@ void bsp_timer_scheduleIn(PORT_TIMER_WIDTH delayTicks) {
 /**
 \brief Cancel a running compare.
 */
-void bsp_timer_cancel_schedule() {
+void bsp_timer_cancel_schedule(void) {
     TA0CCR0               =  0;
     TA0CCTL0             &= ~CCIE;
 }
@@ -115,7 +115,7 @@ void bsp_timer_cancel_schedule() {
 
 \returns The current value of the timer's counter.
 */
-PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
+PORT_TIMER_WIDTH bsp_timer_get_currentValue(void) {
     return TA0R ;
 }
 
@@ -123,7 +123,7 @@ PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
 
 //=========================== interrup handlers ===============================
 
-kick_scheduler_t bsp_timer_isr() {
+kick_scheduler_t bsp_timer_isr(void) {
     // call the callback
     bsp_timer_vars.cb();
     // kick the OS

--- a/bsp/boards/cc1200dk/debugpins.c
+++ b/bsp/boards/cc1200dk/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
     P6DIR |=  0x20;      // frame [P6.5]
     P6DIR |=  0x80;      // slot  [P6.7]
     P6DIR |=  0x08;      // fsm   [P6.3]
@@ -25,68 +25,68 @@ void debugpins_init() {
 }
 
 // P6.5
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
     P6OUT ^=  0x20;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
     P6OUT &= ~0x20;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
     P6OUT |=  0x20;
 }
 
 // P6.7
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
     P6OUT ^=  0x80;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
     P6OUT &= ~0x80;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
     P6OUT |=  0x80;
 }
 
 // P6.3
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
     P6OUT ^=  0x08;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
     P6OUT &= ~0x08;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
     P6OUT |=  0x08;
 }
 
 // P6.2
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
     P6OUT ^=  0x04;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
     P6OUT &= ~0x04;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
     P6OUT |=  0x04;
 }
 
 // P6.0
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
     P6OUT ^=  0x01;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
     P6OUT &= ~0x01;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
     P6OUT |=  0x01;
 }
 
 // P6.1
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
     P6OUT ^=  0x02;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
     P6OUT &= ~0x02;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
     P6OUT |=  0x02;
 }
 

--- a/bsp/boards/cc1200dk/leds.c
+++ b/bsp/boards/cc1200dk/leds.c
@@ -15,26 +15,26 @@
 
 //=========================== public ==========================================
 
-void    leds_init() {
+void    leds_init(void) {
     P4DIR |= BIT0 | BIT1 | BIT2 | BIT3 ;                          // P4DIR = 0bxxxx1111 for LEDs
     P4OUT |= BIT0 | BIT1 | BIT2 | BIT3 ;                          // P4OUT = 0bxxxx1111, all LEDs off
    
 }
 
 // red = LED1 = P4.0
-void    leds_error_on() {
+void    leds_error_on(void) {
     P4OUT     &= ~BIT0;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
     P4OUT     |=  BIT0;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
     P4OUT     ^=  BIT0;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
     return (uint8_t)(P4OUT & BIT0);
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
     uint8_t i;
     volatile uint16_t delay;
     // turn all LEDs off
@@ -48,61 +48,61 @@ void leds_error_blink() {
 }
 
 // yellow = LED2 = P4.1
-void    leds_radio_on() {
+void    leds_radio_on(void) {
     P4OUT     &= ~BIT1;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
     P4OUT     |=  BIT1;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
     P4OUT     ^=  BIT1;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
     return (uint8_t)(P4OUT & BIT1);
 }
 
 // green = LED3 = P4.2
-void    leds_sync_on() {
+void    leds_sync_on(void) {
     P4OUT     &= ~BIT2;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
     P4OUT     |=  BIT2;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
     P4OUT     ^=  BIT2;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
     return (uint8_t)(P4OUT & BIT2);
 }
 
 // red = LED4 = P4.3
-void    leds_debug_on() {
+void    leds_debug_on(void) {
     P4OUT     &= ~BIT3;
 }
 
-void    leds_debug_off() {
+void    leds_debug_off(void) {
     P4OUT     |=  BIT3;
 }
 
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
     P4OUT     ^=  BIT3;
 }
 
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
     return (uint8_t)(P4OUT & BIT3);
 }
 
-void    leds_all_on() {
+void    leds_all_on(void) {
     P4OUT     &= ~(BIT0 | BIT1 | BIT2 | BIT3);
 }
-void    leds_all_off() {
+void    leds_all_off(void) {
     P4OUT     |=  BIT0 | BIT1 | BIT2 | BIT3;
 }
-void    leds_all_toggle() {
+void    leds_all_toggle(void) {
     P4OUT     ^=  BIT0 | BIT1 | BIT2 | BIT3;
 }
 
-void    leds_circular_shift() {
+void    leds_circular_shift(void) {
     uint8_t leds_on;
     // get LED state
     leds_on  = (~P4OUT & BIT0 | BIT1 | BIT2 | BIT3) ;
@@ -122,7 +122,7 @@ void    leds_circular_shift() {
     P4OUT &= ~( leds_on & 0x000f);                  // switch off the leds marked '0' in leds_on
 }
 
-void    leds_increment() {
+void    leds_increment(void) {
     uint8_t leds_on;
     // get LED state
     leds_on  = (~P4OUT & 0x000f);

--- a/bsp/boards/cc1200dk/radiotimer.c
+++ b/bsp/boards/cc1200dk/radiotimer.c
@@ -25,7 +25,7 @@ radiotimer_vars_t radiotimer_vars;
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
    // clear local variables
    memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
 }
@@ -65,7 +65,7 @@ void radiotimer_start(PORT_RADIOTIMER_WIDTH period) {
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH radiotimer_getValue() {
+PORT_RADIOTIMER_WIDTH radiotimer_getValue(void) {
    return TBR;
 }
 
@@ -73,7 +73,7 @@ void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period) {
    TBCCR0   =  period;
 }
 
-PORT_RADIOTIMER_WIDTH radiotimer_getPeriod() {
+PORT_RADIOTIMER_WIDTH radiotimer_getPeriod(void) {
    return TBCCR0;
 }
 
@@ -87,7 +87,7 @@ void radiotimer_schedule(PORT_RADIOTIMER_WIDTH offset) {
    TBCCTL2  =  CCIE;
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
    // reset compare value (also resets interrupt flag)
    TBCCR2   =  0;
    
@@ -97,7 +97,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
+inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime(void) {
    return TBR;
 }
 
@@ -108,7 +108,7 @@ inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t radiotimer_isr() {
+kick_scheduler_t radiotimer_isr(void) {
    PORT_RADIOTIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/cc1200dk/spi.c
+++ b/bsp/boards/cc1200dk/spi.c
@@ -37,7 +37,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
     // clear variables
     memset(&spi_vars,0,sizeof(spi_vars_t));  
    
@@ -179,7 +179,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE   
     // save the byte just received in the RX buffer
     switch (spi_vars.returnType) {

--- a/bsp/boards/cc1200dk/uart.c
+++ b/bsp/boards/cc1200dk/uart.c
@@ -23,7 +23,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    
     P5SEL                      =  0xc0;             //P5.6,7 = USCI_A1
     UCA1CTL1                  |=  UCSWRST;           // **Put state machine in reset**
@@ -68,13 +68,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
     uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
     uart_vars.txCb();
     return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
     uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
     uart_vars.rxCb();
     return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/derfmega/board.c
+++ b/bsp/boards/derfmega/board.c
@@ -30,7 +30,7 @@ volatile uint8_t reset_source;
 
 extern int mote_main();
 
-int main() {
+int main(void) {
    reset_source = MCUSR;
    MCUSR = 0;   
    return mote_main();
@@ -38,7 +38,7 @@ int main() {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    // disable watchdog timer
    wdt_reset();
    wdt_disable();
@@ -69,7 +69,7 @@ void board_init() {
    sei();   
 }
 
-void board_sleep() {
+void board_sleep(void) {
    SMCR = (0x03<<1) | 1; // power-save, enable sleep
  //  sleep_cpu();
    SMCR &= 0xFE; // disable sleep

--- a/bsp/boards/derfmega/bsp_timer.c
+++ b/bsp/boards/derfmega/bsp_timer.c
@@ -31,7 +31,7 @@ bsp_timer_vars_t bsp_timer_vars;
 
 This functions starts the timer
 */
-void bsp_timer_init() {
+void bsp_timer_init(void) {
    
    // clear local variables
    memset(&bsp_timer_vars,0,sizeof(bsp_timer_vars_t));
@@ -65,7 +65,7 @@ void bsp_timer_set_callback(bsp_timer_cbt cb) {
 This function does not stop the timer, it rather resets the value of the
 counter, and cancels a possible pending compare event.
 */
-void bsp_timer_reset() {
+void bsp_timer_reset(void) {
    // disable interrupts
    SCIRQM &= 0xFE;
    
@@ -122,7 +122,7 @@ void bsp_timer_scheduleIn(PORT_TIMER_WIDTH delayTicks) {
 /**
 \brief Cancel a running compare.
 */
-void bsp_timer_cancel_schedule() {
+void bsp_timer_cancel_schedule(void) {
 	SCIRQM &= 0xFE;
 }
 /**
@@ -130,7 +130,7 @@ void bsp_timer_cancel_schedule() {
 
 \returns The current value of the timer's counter.
 */
-PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
+PORT_TIMER_WIDTH bsp_timer_get_currentValue(void) {
    PORT_TIMER_WIDTH retval = SCCNTLL;
    retval |= (PORT_TIMER_WIDTH)SCCNTLH << 8;
    retval |= (PORT_TIMER_WIDTH)SCCNTHL << 16;
@@ -142,7 +142,7 @@ PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
 
 //=========================== interrupt handlers ==============================
 
-uint8_t bsp_timer_isr() {
+uint8_t bsp_timer_isr(void) {
    // call the callback
    bsp_timer_vars.cb();
    // kick the OS

--- a/bsp/boards/derfmega/debugpins.c
+++ b/bsp/boards/derfmega/debugpins.c
@@ -16,53 +16,53 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
 }
 
 // P2.0
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
 }
 
 // P2.1
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
 }
 
 // P2.2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
 }
 
 // P2.3
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
 }
 
 // P2.4
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
 }
 
 // P4.3
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
 }

--- a/bsp/boards/derfmega/leds.c
+++ b/bsp/boards/derfmega/leds.c
@@ -20,80 +20,80 @@
 #define clrb(X,Y) {X &= ~(1<<Y);}
 #define togb(X,Y) {X ^= (1<<Y);}
 
-void leds_init() {
+void leds_init(void) {
    DDRE      |=  0x07 << 2;                        
    PORTE     |= (0x07 << 2);    // led's are tied to VCC
    DPDS0	 |= (0x03 << 4);	// port drivers to 8mA
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
    clrb(PORTE,2);
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    setb(PORTE,2);
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    togb(PORTE,2);
 }
-uint8_t leds_error_isOn() {    
+uint8_t leds_error_isOn(void) {    
    return ((PORTE & (1<<2)) == 0);
 }
 
 // green
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    clrb(PORTE,3);
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    setb(PORTE,3);
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    togb(PORTE,3);
 }
-uint8_t leds_radio_isOn() {      
+uint8_t leds_radio_isOn(void) {      
    return ((PORTE & (1<<3)) == 0);
 }
 
 
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    clrb(PORTE,4);
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    setb(PORTE,4);
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    togb(PORTE,4);
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    return ((PORTE & (1<<4)) == 0);
 }
 
-void    leds_debug_on() {
+void    leds_debug_on(void) {
    // derfmega doesn't have a debug LED :(
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
    // derfmega doesn't have a debug LED :(
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
    // derfmega doesn't have a debug LED :(
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    // eZ430-RF2500 doesn't have a debug LED :(
    return 0;
 }
 
 
-void leds_all_on() {
+void leds_all_on(void) {
    PORTE     &= ~(0x07<<2);
 }
-void leds_all_off() {
+void leds_all_off(void) {
    PORTE     |=  0x07<<2;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
    PORTE     ^=  (0x07<<2);
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t temp_leds;
    if ((PORTE & (0x07<<2))==0) {                      // if no LEDs on, switch on first one
       PORTE |= 0x04;
@@ -109,7 +109,7 @@ void leds_circular_shift() {
    PORTE &= ~(~temp_leds & (0x07<<2));                // switch off the leds marked '0' in temp_leds
 }
 
-void leds_increment() {
+void leds_increment(void) {
    uint8_t led_counter;
    led_counter = ((PORTE & (0x07<<2))+(1<<2));
    PORTE &= ~(0x07<<2); //all LEDs off

--- a/bsp/boards/derfmega/radio.c
+++ b/bsp/boards/derfmega/radio.c
@@ -41,7 +41,7 @@ uint8_t radio_trx_end_isr();
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
 	// turn on radio power and reset
    PRR1 &= ~(1<<PRTRX24);
    TRXPR |= 0x01;
@@ -87,7 +87,7 @@ void radio_setEndFrameCb(radiotimer_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
    TRXPR |= 0x01; // force tranceiver reset
 }
 
@@ -97,7 +97,7 @@ void radio_startTimer(PORT_TIMER_WIDTH period) {
    radiotimer_start(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerValue() {
+PORT_TIMER_WIDTH radio_getTimerValue(void) {
    return radiotimer_getValue();
 }
 
@@ -106,7 +106,7 @@ void radio_setTimerPeriod(PORT_TIMER_WIDTH period) {
    radiotimer_setPeriod(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerPeriod() {
+PORT_TIMER_WIDTH radio_getTimerPeriod(void) {
    return radiotimer_getPeriod();
 }
 
@@ -123,11 +123,11 @@ void radio_setFrequency(uint8_t frequency) {
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    PRR1 &= ~_BV(PRTRX24);
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
    // turn radio off
@@ -156,7 +156,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
    
@@ -172,7 +172,7 @@ void radio_txEnable() {
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
    
@@ -193,7 +193,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
    
@@ -210,7 +210,7 @@ void radio_rxEnable() {
    radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    // nothing to do
 }
 
@@ -265,12 +265,12 @@ void radio_internalReadRxFifo(uint8_t* pBufRead,
 
 //=========================== interrupt handlers ==============================
 
-uint8_t radio_isr() {
+uint8_t radio_isr(void) {
 	// should not be called
 	return 0;
 }
 
-uint8_t radio_rx_start_isr() {
+uint8_t radio_rx_start_isr(void) {
    PORT_TIMER_WIDTH capturedTime;
    // capture the time
    capturedTime = radiotimer_getCapturedTime();	
@@ -284,7 +284,7 @@ uint8_t radio_rx_start_isr() {
 	return 0;
 }
 
-uint8_t radio_trx_end_isr() {
+uint8_t radio_trx_end_isr(void) {
    PORT_TIMER_WIDTH capturedTime;
    // capture the time
    capturedTime = radiotimer_getCapturedTime();	

--- a/bsp/boards/derfmega/radiotimer.c
+++ b/bsp/boards/derfmega/radiotimer.c
@@ -27,7 +27,7 @@ uint8_t radiotimer_compare_isr();
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
    // clear local variables
    memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
 }
@@ -76,7 +76,7 @@ void radiotimer_start(PORT_RADIOTIMER_WIDTH period) {
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH radiotimer_getValue() {
+PORT_RADIOTIMER_WIDTH radiotimer_getValue(void) {
    return radiotimer_getCapturedTime();
 }
 
@@ -87,7 +87,7 @@ void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period) {
 	SCOCR3LL = (uint8_t)period;
 }
 
-PORT_RADIOTIMER_WIDTH radiotimer_getPeriod() {
+PORT_RADIOTIMER_WIDTH radiotimer_getPeriod(void) {
 	return *((PORT_RADIOTIMER_WIDTH *)(&SCOCR3LL));
 }
 
@@ -106,7 +106,7 @@ void radiotimer_schedule(PORT_RADIOTIMER_WIDTH offset) {
    SCIRQM |= _BV(1);
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
    // reset value
    *((PORT_RADIOTIMER_WIDTH *)(&SCOCR2LL)) = 0;
    SCOCR2LL = 0;
@@ -117,7 +117,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
+inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime(void) {
    return *((PORT_RADIOTIMER_WIDTH *)(&SCCNTLL)) - *((PORT_RADIOTIMER_WIDTH *)(&SCBTSRLL));
 }
 
@@ -125,11 +125,11 @@ inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
 
 //=========================== interrupt handlers ==============================
 
-uint8_t radiotimer_isr() {
+uint8_t radiotimer_isr(void) {
 	while(1);
 }
 
-uint8_t radiotimer_compare_isr() {
+uint8_t radiotimer_compare_isr(void) {
          if (radiotimer_vars.compare_cb!=NULL) {
 	         // call the callback
 	         radiotimer_vars.compare_cb();
@@ -139,7 +139,7 @@ uint8_t radiotimer_compare_isr() {
 		 return 0;
 }
 
-uint8_t radiotimer_overflow_isr() {
+uint8_t radiotimer_overflow_isr(void) {
 		SCCR0 |= _BV(SCMBTS);
          if (radiotimer_vars.overflow_cb!=NULL) {
 	         // call the callback

--- a/bsp/boards/derfmega/sctimer_mac.c
+++ b/bsp/boards/derfmega/sctimer_mac.c
@@ -19,7 +19,7 @@ on the derfmega we use timer 2 with asynchronous operation
 
 //=========================== public ==========================================
 
-void sctimer_init() {
+void sctimer_init(void) {
    PRR0 &= ~(1<<PRTIM2); // turn on timer 2 for crystal
    SCCR0 = 0b00111000; // enable symbol counter, 32KHz clock, auto timestamp, no relative compare
    SCCR1 = 0; // no backoff slot counter
@@ -41,7 +41,7 @@ void sctimer_schedule(PORT_TIMER_WIDTH val) {
    while(SCBSY & 1);
 }
 
-PORT_TIMER_WIDTH sctimer_getValue() {
+PORT_TIMER_WIDTH sctimer_getValue(void) {
 	PORT_TIMER_WIDTH val = SCCNTLL;
 	val |= ((PORT_TIMER_WIDTH)SCCNTLH<<8);
 	val |= ((PORT_TIMER_WIDTH)SCCNTHL<<16);
@@ -49,7 +49,7 @@ PORT_TIMER_WIDTH sctimer_getValue() {
    return val;
 }
 
-void sctimer_clearISR() {
+void sctimer_clearISR(void) {
 	SCIRQM &= 0xFE;
 }
 

--- a/bsp/boards/derfmega/sctimer_tmr2.c
+++ b/bsp/boards/derfmega/sctimer_tmr2.c
@@ -19,7 +19,7 @@ on the derfmega we use timer 2 with asynchronous operation
 
 //=========================== public ==========================================
 
-void sctimer_init() {
+void sctimer_init(void) {
    // enable power
    PRR0 &= ~(1<<PRTIM2);
    
@@ -43,11 +43,11 @@ void sctimer_schedule(PORT_TIMER_WIDTH val) {
    while(ASSR & (1<<OCR2AUB));
 }
 
-PORT_TIMER_WIDTH sctimer_getValue() {
+PORT_TIMER_WIDTH sctimer_getValue(void) {
    return TCNT2;
 }
 
-void sctimer_clearISR() {
+void sctimer_clearISR(void) {
 	TIFR2 |= (1<<OCF2A);
 }
 

--- a/bsp/boards/derfmega/uart.c
+++ b/bsp/boards/derfmega/uart.c
@@ -25,7 +25,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
 	//turn on power
 	PRR0 &= ~(1<<PRUSART0);
 	
@@ -76,13 +76,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-uint8_t uart_isr_tx() {
+uint8_t uart_isr_tx(void) {
    if(uart_vars.txCb)
 		uart_vars.txCb();
    return 0;
 }
 
-uint8_t uart_isr_rx() {
+uint8_t uart_isr_rx(void) {
 	char dummy;
 	if (uart_vars.rxCb)
 		uart_vars.rxCb();

--- a/bsp/boards/eldorado/board.c
+++ b/bsp/boards/eldorado/board.c
@@ -19,7 +19,7 @@
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
 
   DisableWatchdog;
   //at the beginning, we source our uC off the internal clock (8MhZ), whihc is innacurate
@@ -41,7 +41,7 @@ void board_init() {
    
 }
 
-void board_sleep() {
+void board_sleep(void) {
   //poipoi __bis_SR_register(GIE+LPM3_bits);             // sleep, but leave ACLK on
 }
 

--- a/bsp/boards/eldorado/leds.c
+++ b/bsp/boards/eldorado/leds.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void leds_init() {                    
+void leds_init(void) {                    
 	//initialize led pins as outputs
 	LED1DIR = DDIR_OUTPUT;   
 	LED2DIR = DDIR_OUTPUT;	
@@ -26,50 +26,50 @@ void leds_init() {
 #endif
 }
 
-void led_error_on() {
+void led_error_on(void) {
    LED1 = LED_ON;
 }
 
-void led_error_off() {
+void led_error_off(void) {
 	LED1 = LED_OFF;
 }
-void led_error_toggle() {
+void led_error_toggle(void) {
 	LED1 = ~LED1;
 }
 
-void led_radio_on() {
+void led_radio_on(void) {
    LED2 = LED_ON;;
 }
-void led_radio_off() {
+void led_radio_off(void) {
 	LED2 = LED_OFF;;
 }
-void led_radio_toggle() {
+void led_radio_toggle(void) {
 	LED2 = ~LED2;
 }
 
-void led_sync_on() {
+void led_sync_on(void) {
 	LED3 = LED_ON;
 }
-void led_sync_off() {
+void led_sync_off(void) {
    LED3 = LED_OFF;
 }
-void led_sync_toggle() {
+void led_sync_toggle(void) {
 	LED3 = ~LED3;
 }
 
-void led_all_on() {
+void led_all_on(void) {
 	LED1 = LED_ON;
 	LED2 = LED_ON;
 	LED3 = LED_ON;
 	LED4 = LED_ON;
 }
-void led_all_off() {
+void led_all_off(void) {
 	LED1 = LED_OFF;
 	LED2 = LED_OFF;
 	LED3 = LED_OFF;
 	LED4 = LED_OFF;
 }
-void led_all_toggle() {
+void led_all_toggle(void) {
 	LED1 = ~LED1;
 	LED2 = ~LED2;
 	LED3 = ~LED3;
@@ -78,7 +78,7 @@ void led_all_toggle() {
 
 
 	bool led_temp;
-void leds_circular_shift() {
+void leds_circular_shift(void) {
 	if((LED1==LED_OFF)&&(LED2==LED_OFF)&&(LED3==LED_OFF)){              // MAKING A LED ON IF THEY ARE ALL OFF
 		LED1=LED_ON;
 	}  else if ((LED1==LED_ON)&&(LED2==LED_ON)&&(LED3==LED_ON)){        // MAKING A LED OFF IF THEY ARE ALL ON
@@ -90,7 +90,7 @@ void leds_circular_shift() {
 	LED1 = led_temp;
 }
 	unsigned int LED = 0;
-void leds_increment() {
+void leds_increment(void) {
 
 	LED = !LED1;
 	LED = LED | (!LED2*2);    // AQUIRES THE LEDS STATE

--- a/bsp/boards/eldorado/radio.c
+++ b/bsp/boards/eldorado/radio.c
@@ -34,7 +34,7 @@ void    radio_spiReadRxFifo(uint8_t* bufRead, uint8_t length);
 
 //=========================== public ==========================================
 
-void radio_init() {
+void radio_init(void) {
    //start fabien code:
 	uint8_t temp;
    IRQInit();
@@ -138,7 +138,7 @@ void radio_setEndFrameCb(radiotimer_capture_cbt cb) {
    radio_vars.endFrameCb = cb;
 }
 */
-void radio_reset() {
+void radio_reset(void) {
    PTDD_PTDD3 = 0;
    PTDD_PTDD3 = 1;//goes back to idle mode
 }
@@ -149,7 +149,7 @@ void radio_setFrequency(uint8_t frequency) {
    radio_spiWriteReg(LO1_NUM_ADDR,frequency-11);//in this radio they index the channels from 0 to 15
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    //poipoi
    //to leave doze mode, assert ATTN then deassert it
    MC13192_ATTN = 0;
@@ -161,7 +161,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_spiWriteTxFifo(packet,len);
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    // turn on radio's PLL
      //read status reg
    uint16_t stat_reg = radio_spiReadReg(MODE_ADDR);
@@ -176,7 +176,7 @@ void radio_txEnable() {
    while((radio_spiReadReg(STATUS_ADDR) & 0x8000)); // busy wait until pll locks
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    // send packet by assterting the RTXEN pin
    MC13192_RTXEN = 1;
    
@@ -191,7 +191,7 @@ void radio_txNow() {
    //poipoiieee154e_startOfFrame(ieee154etimer_getCapturedTime());
 }
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    //read status reg
    uint16_t stat_reg = radio_spiReadReg(MODE_ADDR);
    stat_reg &= 0xfff8;
@@ -206,7 +206,7 @@ void radio_rxEnable() {
    while((radio_spiReadReg(STATUS_ADDR) & 0x8000)); // busy wait until pll locks
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    // nothing to do
 }
 
@@ -233,7 +233,7 @@ void radio_getReceivedFrame(uint8_t* bufRead,
    //modify this function with the new variables: lenRead, maxBufLen, rssi, lqi, crc: look in telos for examples.
 }
 
-void radio_rfOff() {// turn radio off
+void radio_rfOff(void) {// turn radio off
    uint16_t stat_reg;
    
    MC13192_RTXEN = 0;//go back to idle

--- a/bsp/boards/eldorado/spi.c
+++ b/bsp/boards/eldorado/spi.c
@@ -40,7 +40,7 @@ spi_vars_t spi_vars;
 //=========================== prototypes ======================================
 
 //=========================== public ==========================================
-void spi_init() {
+void spi_init(void) {
 	SPI1C1 = 0x50;   /*  
 	                      *  0b01010000
 	                      *    ||||||||__ SPI serial data transfers start with MSB

--- a/bsp/boards/eldorado/uart.c
+++ b/bsp/boards/eldorado/uart.c
@@ -44,7 +44,7 @@ void interrupt VectorNumber_Vsci2rx SCI2RX_ISR(void);
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
 
 	SCI2C2 = 0x00;                       /* Disable the SCI2 module */
 	(void)(SCI2S1 == 0);                 /* Dummy read of the SCI2S1 registr to clear flags */
@@ -118,7 +118,7 @@ void uart_rxSetup(uint8_t*    rxBuf,
    
 }
 
-void uart_rxStart() {
+void uart_rxStart(void) {
    // enable UART RX interrupt
    SCI2C2_RIE = 0x1;
 }
@@ -141,14 +141,14 @@ void uart_readBytes(uint8_t* buf, uint8_t numBytes) {
    uart_vars.rxBufFill      -= numBytes;
 }
 
-void uart_rxStop() {
+void uart_rxStop(void) {
    // disable UART1 RX interrupt
 	SCI2C2_RIE = 0x0;
 }
 
 //=========================== private =========================================
 
-void reset_rxBuf() {
+void reset_rxBuf(void) {
    uart_vars.rxBufWrPtr      = uart_vars.rxBuf;
    uart_vars.rxBufRdPtr      = uart_vars.rxBuf;
    uart_vars.rxBufFill       = 0;

--- a/bsp/boards/ez430-rf2500/board.c
+++ b/bsp/boards/ez430-rf2500/board.c
@@ -22,13 +22,13 @@
 
 extern int mote_main();
 
-int main() {
+int main(void) {
    return mote_main();
 }
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    // disable watchdog timer
    WDTCTL  = WDTPW + WDTHOLD;
    
@@ -56,7 +56,7 @@ void board_init() {
    
 }
 
-void board_sleep() {
+void board_sleep(void) {
    __bis_SR_register(GIE+LPM0_bits);             // sleep, but leave ACLK on
 }
 

--- a/bsp/boards/ez430-rf2500/bsp_timer.c
+++ b/bsp/boards/ez430-rf2500/bsp_timer.c
@@ -34,7 +34,7 @@ bsp_timer_vars_t bsp_timer_vars;
 This functions starts the timer, i.e. the counter increments, but doesn't set
 any compare registers, so no interrupt will fire.
 */
-void bsp_timer_init() {
+void bsp_timer_init(void) {
    
    // clear local variables
    memset(&bsp_timer_vars,0,sizeof(bsp_timer_vars_t));
@@ -65,7 +65,7 @@ void bsp_timer_set_callback(bsp_timer_cbt cb) {
 This function does not stop the timer, it rather resets the value of the
 counter, and cancels a possible pending compare event.
 */
-void bsp_timer_reset() {
+void bsp_timer_reset(void) {
    // reset compare
    TBCCR0               =  0;
    TBCCTL0              =  0;
@@ -116,7 +116,7 @@ void bsp_timer_scheduleIn(PORT_TIMER_WIDTH delayTicks) {
 /**
 \brief Cancel a running compare.
 */
-void bsp_timer_cancel_schedule() {
+void bsp_timer_cancel_schedule(void) {
    TBCCR0               =  0;
    TBCCTL0             &= ~CCIE;
 }
@@ -126,7 +126,7 @@ void bsp_timer_cancel_schedule() {
 
 \returns The current value of the timer's counter.
 */
-PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
+PORT_TIMER_WIDTH bsp_timer_get_currentValue(void) {
    return TBR;
 }
 
@@ -134,7 +134,7 @@ PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
 
 //=========================== interrupt handlers ==============================
 
-uint8_t bsp_timer_isr() {
+uint8_t bsp_timer_isr(void) {
    // call the callback
    bsp_timer_vars.cb();
    // kick the OS

--- a/bsp/boards/ez430-rf2500/debugpins.c
+++ b/bsp/boards/ez430-rf2500/debugpins.c
@@ -16,7 +16,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    P2DIR |=  0x01;      // frame
    P2DIR |=  0x02;      // slot
    P2DIR |=  0x04;      // fsm
@@ -26,67 +26,67 @@ void debugpins_init() {
 }
 
 // P2.0
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    P2OUT ^=  0x01;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
    P2OUT &= ~0x01;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    P2OUT |=  0x01;
 }
 
 // P2.1
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
    P2OUT ^=  0x02;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
    P2OUT &= ~0x02;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
    P2OUT |=  0x02;
 }
 
 // P2.2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
    P2OUT ^=  0x04;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
    P2OUT &= ~0x04;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
    P2OUT |=  0x04;
 }
 
 // P2.3
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
    P2OUT ^=  0x08;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
    P2OUT &= ~0x08;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
    P2OUT |=  0x08;
 }
 
 // P2.4
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
    P2OUT ^=  0x10;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
    P2OUT &= ~0x10;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
    P2OUT |=  0x10;
 }
 
 // P4.3
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
    P4OUT ^=  0x08;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
    P4OUT &= ~0x08;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
    P4OUT |=  0x08;
 }

--- a/bsp/boards/ez430-rf2500/leds.c
+++ b/bsp/boards/ez430-rf2500/leds.c
@@ -17,80 +17,80 @@
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
    P1DIR      |=  0x03;                          // P1DIR = 0bxxxx0011 for LEDs
    P1OUT      &= ~0x03;                          // P1OUT = 0bxxxx0000, all LEDs off
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
    P1OUT     |=  0x01;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    P1OUT     &= ~0x01;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    P1OUT     ^=  0x01;
 }
-uint8_t leds_error_isOn() {    
+uint8_t leds_error_isOn(void) {    
    return (P1OUT & 0x01)>>0;
 }
 
 // green
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    P1OUT     |=  0x02;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    P1OUT     &= ~0x02;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    P1OUT     ^=  0x02;
 }
-uint8_t leds_radio_isOn() {      
+uint8_t leds_radio_isOn(void) {      
    return (P1OUT & 0x02)>>1;
 }
 
 
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    // eZ430-RF2500 doesn't have a sync LED :(
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    // eZ430-RF2500 doesn't have a sync LED :(
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    // eZ430-RF2500 doesn't have a sync LED :(
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    // eZ430-RF2500 doesn't have a sync LED :(
    return 0;
 }
 
-void    leds_debug_on() {
+void    leds_debug_on(void) {
    // eZ430-RF2500 doesn't have a debug LED :(
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
    // eZ430-RF2500 doesn't have a debug LED :(
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
    // eZ430-RF2500 doesn't have a debug LED :(
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    // eZ430-RF2500 doesn't have a debug LED :(
    return 0;
 }
 
 
-void leds_all_on() {
+void leds_all_on(void) {
    P1OUT     &= ~0x03;
 }
-void leds_all_off() {
+void leds_all_off(void) {
    P1OUT     |=  0x03;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
    P1OUT     ^=  0x03;
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t temp_leds;
    if ((P1OUT & 0x03)==0) {                      // if no LEDs on, switch on first one
       P1OUT |= 0x01;
@@ -105,7 +105,7 @@ void leds_circular_shift() {
    P1OUT &= ~(~temp_leds & 0x03);                // switch off the leds marked '0' in temp_leds
 }
 
-void leds_increment() {
+void leds_increment(void) {
    uint8_t led_counter;
    led_counter = ((P1OUT & 0x03)+1);
    P1OUT &= ~0x03; //all LEDs off

--- a/bsp/boards/ez430-rf2500/radiotimer.c
+++ b/bsp/boards/ez430-rf2500/radiotimer.c
@@ -25,7 +25,7 @@ radiotimer_vars_t radiotimer_vars;
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
    // clear local variables
    memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
 }
@@ -72,7 +72,7 @@ void radiotimer_start(PORT_RADIOTIMER_WIDTH period) {
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH radiotimer_getValue() {
+PORT_RADIOTIMER_WIDTH radiotimer_getValue(void) {
    return TAR;
 }
 
@@ -80,7 +80,7 @@ void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period) {
    TACCR0   =  period;
 }
 
-PORT_RADIOTIMER_WIDTH radiotimer_getPeriod() {
+PORT_RADIOTIMER_WIDTH radiotimer_getPeriod(void) {
    return TACCR0;
 }
 
@@ -94,7 +94,7 @@ void radiotimer_schedule(PORT_RADIOTIMER_WIDTH offset) {
    TACCTL1  =  CCIE;
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
    // reset CCR1 value (also resets interrupt flag)
    TACCR1   =  0;
    
@@ -104,7 +104,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
+inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime(void) {
    return TAR;
 }
 
@@ -112,7 +112,7 @@ inline PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
 
 //=========================== interrupt handlers ==============================
 
-uint8_t radiotimer_isr() {
+uint8_t radiotimer_isr(void) {
    PORT_RADIOTIMER_WIDTH taiv_temp = TAIV;                    // read only once because accessing TAIV resets it
    switch (taiv_temp) {
       case 0x0002: // capture/compare CCR1

--- a/bsp/boards/ez430-rf2500/spi.c
+++ b/bsp/boards/ez430-rf2500/spi.c
@@ -39,7 +39,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
    memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -162,7 +162,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-uint8_t spi_isr() {
+uint8_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/ez430-rf2500/uart.c
+++ b/bsp/boards/ez430-rf2500/uart.c
@@ -26,7 +26,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    
@@ -72,13 +72,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-uint8_t uart_isr_tx() {
+uint8_t uart_isr_tx(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.txCb();
    return 0;
 }
 
-uint8_t uart_isr_rx() {
+uint8_t uart_isr_rx(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.rxCb();
    return 0;

--- a/bsp/boards/gina/board.c
+++ b/bsp/boards/gina/board.c
@@ -38,7 +38,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    uint8_t eui[8];
    
    // disable watchdog timer
@@ -99,11 +99,11 @@ void board_init() {
    }
 }
 
-void board_sleep() {
+void board_sleep(void) {
    __bis_SR_register(GIE+LPM3_bits);             // sleep, but leave ACLK on
 }
 
-void board_reset() {
+void board_reset(void) {
    WDTCTL = (WDTPW+0x1200) + WDTHOLD; // writing a wrong watchdog password to causes handler to reset
 }
 

--- a/bsp/boards/gina/debugpins.c
+++ b/bsp/boards/gina/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    P4DIR |=  0x20;      // frame
    P4DIR |=  0x02 ;     // slot
    P4DIR |=  0x04;      // fsm
@@ -32,67 +32,67 @@ void debugpins_init() {
 }
 
 // P4.5
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    P4OUT ^=  0x20;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
    P4OUT &= ~0x20;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    P4OUT |=  0x20;
 }
 
 // P4.1
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
    P4OUT ^=  0x02;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
    P4OUT &= ~0x02;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
    P4OUT |=  0x02;
 }
 
 // P4.2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
    P4OUT ^=  0x04;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
    P4OUT &= ~0x04;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
    P4OUT |=  0x04;
 }
 
 // P4.3
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
    P4OUT ^=  0x08;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
    P4OUT &= ~0x08;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
    P4OUT |=  0x08;
 }
 
 // P4.4
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
    P4OUT ^=  0x10;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
    P4OUT &= ~0x10;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
    P4OUT |=  0x10;
 }
 
 // P1.1
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
    P1OUT ^=  0x02;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
    P1OUT &= ~0x02;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
    P1OUT |=  0x02;
 }

--- a/bsp/boards/gina/i2c.c
+++ b/bsp/boards/gina/i2c.c
@@ -44,7 +44,7 @@ uint8_t  i2c_busy(uint8_t bus_num);
 
 //#define bus_num 1
 
-void i2c_init() {
+void i2c_init(void) {
    i2c_control.ctl0[0]       = &UCB0CTL0;
    i2c_control.ctl0[1]       = &UCB1CTL0;
    i2c_control.ctl1[0]       = &UCB0CTL1;

--- a/bsp/boards/gina/leds.c
+++ b/bsp/boards/gina/leds.c
@@ -16,78 +16,78 @@
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
    P2DIR      |=  0x0F;                          // P2DIR = 0bxxxx1111 for LEDs
    P2OUT      &= ~0x0F;                          // P2OUT = 0bxxxx0000, all LEDs off
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
    P2OUT     |=  0x08;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    P2OUT     &= ~0x08;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    P2OUT     ^=  0x08;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
    return (uint8_t)(P2OUT & 0x08)>>3;
 }
 
 // orange
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    P2OUT     |=  0x04;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    P2OUT     &= ~0x04;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    P2OUT     ^=  0x04;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
    return (P2OUT & 0x04)>>4;
 }
 
 // green
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    P2OUT     |=  0x02;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    P2OUT     &= ~0x02;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    P2OUT     ^=  0x02;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    return (P2OUT & 0x02)>>1;
 }
 
 // yellow
-void    leds_debug_on() {
+void    leds_debug_on(void) {
    P2OUT     |=  0x01;
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
    P2OUT     &= ~0x01;
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
    P2OUT     ^=  0x01;
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    return (P2OUT & 0x01)>>0;
 }
 
-void leds_all_on() {
+void leds_all_on(void) {
    P5OUT     &= ~0x0F;
 }
-void leds_all_off() {
+void leds_all_off(void) {
    P5OUT     |=  0x0F;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
    P5OUT     ^=  0x0F;
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    // turn all LEDs off
@@ -101,7 +101,7 @@ void leds_error_blink() {
    }
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t temp_leds;
    if ((P2OUT & 0x0F)==0) {                      // if no LEDs on, switch on first one
       P2OUT |= 0x01;
@@ -116,7 +116,7 @@ void leds_circular_shift() {
    P2OUT &= ~(~temp_leds & 0x0F);                // switch off the leds marked '0' in temp_leds
 }
 
-void leds_increment() {
+void leds_increment(void) {
    uint8_t led_counter;
    led_counter = ((P2OUT & 0x0f)+1);
    P2OUT &= ~0x0f; //all LEDs off

--- a/bsp/boards/gina/sctimer.c
+++ b/bsp/boards/gina/sctimer.c
@@ -105,7 +105,7 @@ void sctimer_disable(void){
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
    PORT_TIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/gina/spi.c
+++ b/bsp/boards/gina/spi.c
@@ -38,7 +38,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
    memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -161,7 +161,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/gina/uart.c
+++ b/bsp/boards/gina/uart.c
@@ -25,7 +25,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    
@@ -71,13 +71,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.txCb();
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.rxCb();
    return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/iot-lab_A8-M3/board.c
+++ b/bsp/boards/iot-lab_A8-M3/board.c
@@ -98,7 +98,7 @@ void board_init(void){
     NVIC_radio();
 }
 
-void board_sleep() {
+void board_sleep(void) {
     DBGMCU_Config(DBGMCU_STOP, ENABLE);
     // Enable PWR and BKP clock
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR | RCC_APB1Periph_BKP, ENABLE);

--- a/bsp/boards/iot-lab_A8-M3/debugpins.c
+++ b/bsp/boards/iot-lab_A8-M3/debugpins.c
@@ -14,29 +14,29 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {}
+void debugpins_init(void) {}
 
-void debugpins_frame_toggle() {}
-void debugpins_frame_clr() {}
-void debugpins_frame_set() {}
+void debugpins_frame_toggle(void) {}
+void debugpins_frame_clr(void) {}
+void debugpins_frame_set(void) {}
 
-void debugpins_slot_toggle() {}
-void debugpins_slot_clr() {}
-void debugpins_slot_set() {}
+void debugpins_slot_toggle(void) {}
+void debugpins_slot_clr(void) {}
+void debugpins_slot_set(void) {}
 
-void debugpins_fsm_toggle() {}
-void debugpins_fsm_clr() {}
-void debugpins_fsm_set() {}
+void debugpins_fsm_toggle(void) {}
+void debugpins_fsm_clr(void) {}
+void debugpins_fsm_set(void) {}
 
-void debugpins_task_toggle() {}
-void debugpins_task_clr() {}
-void debugpins_task_set() {}
+void debugpins_task_toggle(void) {}
+void debugpins_task_clr(void) {}
+void debugpins_task_set(void) {}
 
-void debugpins_isr_toggle() {}
-void debugpins_isr_clr() {}
-void debugpins_isr_set() {}
+void debugpins_isr_toggle(void) {}
+void debugpins_isr_clr(void) {}
+void debugpins_isr_set(void) {}
 
-void debugpins_radio_toggle() {}
-void debugpins_radio_clr() {}
-void debugpins_radio_set() {}
+void debugpins_radio_toggle(void) {}
+void debugpins_radio_clr(void) {}
+void debugpins_radio_set(void) {}
 

--- a/bsp/boards/iot-lab_A8-M3/leds.c
+++ b/bsp/boards/iot-lab_A8-M3/leds.c
@@ -72,7 +72,7 @@ uint8_t leds_error_isOn()
   }
   return bitstatus;
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
     for(int i=0;i<16;i++) {
         leds_error_toggle();
         Delay();
@@ -133,10 +133,10 @@ uint8_t leds_radio_isOn()
   return bitstatus;
 }
 // yellow
-void leds_debug_on() {}
-void leds_debug_off() {}
-void leds_debug_toggle() {}
-uint8_t leds_debug_isOn() {
+void leds_debug_on(void) {}
+void leds_debug_off(void) {}
+void leds_debug_toggle(void) {}
+uint8_t leds_debug_isOn(void) {
   // IoT-lab_M3 does not have a debug led
   return 0;
 }
@@ -170,7 +170,7 @@ void leds_circular_shift()
   Delay();
 }
 
-void leds_increment() {}
+void leds_increment(void) {}
 
 //=========================== private =========================================
 

--- a/bsp/boards/iot-lab_A8-M3/sctimer.c
+++ b/bsp/boards/iot-lab_A8-M3/sctimer.c
@@ -38,7 +38,7 @@ sctimer_vars_t sctimer_vars;
 
 //===== admin
 
-void sctimer_init() {
+void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
     //enable BKP and PWR, Clock
@@ -85,7 +85,7 @@ void sctimer_set_callback(sctimer_cbt cb){
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH sctimer_readCounter() {
+PORT_RADIOTIMER_WIDTH sctimer_readCounter(void) {
     uint32_t counter;
     RTC_WaitForSynchro();
     counter = RTC_GetCounter();
@@ -180,12 +180,12 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_enable() {
+void sctimer_enable(void) {
     RTC_ClearFlag(RTC_IT_ALR);
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_disable() {
+void sctimer_disable(void) {
     RTC_ITConfig(RTC_IT_ALR, DISABLE);
 }
 
@@ -193,7 +193,7 @@ void sctimer_disable() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
     if (sctimer_vars.sctimer_cb!=NULL) {
         
         RCC_Wakeup();

--- a/bsp/boards/iot-lab_A8-M3/spi.c
+++ b/bsp/boards/iot-lab_A8-M3/spi.c
@@ -41,7 +41,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
  // clear variables
   memset(&spi_vars,0,sizeof(spi_vars_t));
  
@@ -189,7 +189,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/iot-lab_A8-M3/uart.c
+++ b/bsp/boards/iot-lab_A8-M3/uart.c
@@ -30,7 +30,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
     
     GPIO_InitTypeDef  GPIO_InitStructure;
     USART_InitTypeDef USART_InitStructure;
@@ -77,21 +77,21 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     uart_vars.rxCb = rxCb;
 }
 
-void uart_enableInterrupts() {
+void uart_enableInterrupts(void) {
     USART_ITConfig(USART1, USART_IT_TC,   ENABLE);
     USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
 }
 
-void uart_disableInterrupts() {
+void uart_disableInterrupts(void) {
     USART_ITConfig(USART1, USART_IT_TC,   DISABLE);
     USART_ITConfig(USART1, USART_IT_RXNE, DISABLE);
 }
 
-void uart_clearRxInterrupts() {
+void uart_clearRxInterrupts(void) {
     USART_ClearFlag(USART1, USART_FLAG_RXNE);
 }
 
-void uart_clearTxInterrupts() {
+void uart_clearTxInterrupts(void) {
     USART_ClearFlag(USART1, USART_FLAG_TC);
 }
 
@@ -99,7 +99,7 @@ void uart_writeByte(uint8_t byteToWrite) {
     USART_SendData(USART1,(uint16_t)byteToWrite);
 }
 
-uint8_t uart_readByte() {
+uint8_t uart_readByte(void) {
     uint16_t temp;
 
     temp = USART_ReceiveData(USART1);
@@ -108,13 +108,13 @@ uint8_t uart_readByte() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
     uart_clearTxInterrupts();
     uart_vars.txCb();
     return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
     uart_clearRxInterrupts();
     uart_vars.rxCb();
     return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/iot-lab_M3/debugpins.c
+++ b/bsp/boards/iot-lab_M3/debugpins.c
@@ -14,29 +14,29 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {}
+void debugpins_init(void) {}
 
-void debugpins_frame_toggle() {}
-void debugpins_frame_clr() {}
-void debugpins_frame_set() {}
+void debugpins_frame_toggle(void) {}
+void debugpins_frame_clr(void) {}
+void debugpins_frame_set(void) {}
 
-void debugpins_slot_toggle() {}
-void debugpins_slot_clr() {}
-void debugpins_slot_set() {}
+void debugpins_slot_toggle(void) {}
+void debugpins_slot_clr(void) {}
+void debugpins_slot_set(void) {}
 
-void debugpins_fsm_toggle() {}
-void debugpins_fsm_clr() {}
-void debugpins_fsm_set() {}
+void debugpins_fsm_toggle(void) {}
+void debugpins_fsm_clr(void) {}
+void debugpins_fsm_set(void) {}
 
-void debugpins_task_toggle() {}
-void debugpins_task_clr() {}
-void debugpins_task_set() {}
+void debugpins_task_toggle(void) {}
+void debugpins_task_clr(void) {}
+void debugpins_task_set(void) {}
 
-void debugpins_isr_toggle() {}
-void debugpins_isr_clr() {}
-void debugpins_isr_set() {}
+void debugpins_isr_toggle(void) {}
+void debugpins_isr_clr(void) {}
+void debugpins_isr_set(void) {}
 
-void debugpins_radio_toggle() {}
-void debugpins_radio_clr() {}
-void debugpins_radio_set() {}
+void debugpins_radio_toggle(void) {}
+void debugpins_radio_clr(void) {}
+void debugpins_radio_set(void) {}
 

--- a/bsp/boards/iot-lab_M3/leds.c
+++ b/bsp/boards/iot-lab_M3/leds.c
@@ -72,7 +72,7 @@ uint8_t leds_error_isOn()
   }
   return bitstatus;
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
     for(int i=0;i<16;i++) {
         leds_error_toggle();
         Delay();
@@ -133,10 +133,10 @@ uint8_t leds_radio_isOn()
   return bitstatus;
 }
 // yellow
-void leds_debug_on() {}
-void leds_debug_off() {}
-void leds_debug_toggle() {}
-uint8_t leds_debug_isOn() {
+void leds_debug_on(void) {}
+void leds_debug_off(void) {}
+void leds_debug_toggle(void) {}
+uint8_t leds_debug_isOn(void) {
   // IoT-lab_M3 does not have a debug led
   return 0;
 }
@@ -170,7 +170,7 @@ void leds_circular_shift()
   Delay();
 }
 
-void leds_increment() {}
+void leds_increment(void) {}
 
 //=========================== private =========================================
 

--- a/bsp/boards/iot-lab_M3/sctimer.c
+++ b/bsp/boards/iot-lab_M3/sctimer.c
@@ -37,7 +37,7 @@ sctimer_vars_t sctimer_vars;
 
 //===== admin
 
-void sctimer_init() {
+void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
     //enable BKP and PWR, Clock
@@ -84,7 +84,7 @@ void sctimer_set_callback(sctimer_cbt cb){
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH sctimer_readCounter() {
+PORT_RADIOTIMER_WIDTH sctimer_readCounter(void) {
     uint32_t counter;
     RTC_WaitForSynchro();
     counter = RTC_GetCounter();
@@ -180,12 +180,12 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_enable() {
+void sctimer_enable(void) {
     RTC_ClearFlag(RTC_IT_ALR);
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_disable() {
+void sctimer_disable(void) {
     RTC_ITConfig(RTC_IT_ALR, DISABLE);
 }
 
@@ -193,7 +193,7 @@ void sctimer_disable() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
     if (sctimer_vars.sctimer_cb!=NULL) {
         
         RCC_Wakeup();

--- a/bsp/boards/iot-lab_M3/spi.c
+++ b/bsp/boards/iot-lab_M3/spi.c
@@ -43,7 +43,7 @@ volatile spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
  // clear variables
   memset((void*)&spi_vars,0,sizeof(spi_vars_t));
  
@@ -190,7 +190,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/iot-lab_M3/uart.c
+++ b/bsp/boards/iot-lab_M3/uart.c
@@ -30,7 +30,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
     
     GPIO_InitTypeDef  GPIO_InitStructure;
     USART_InitTypeDef USART_InitStructure;
@@ -76,19 +76,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     uart_vars.rxCb = rxCb;
 }
 
-void uart_enableInterrupts() {
+void uart_enableInterrupts(void) {
     USART_ITConfig(USART1, USART_IT_TC,   ENABLE);
     USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
 }
 
-void uart_disableInterrupts() {
+void uart_disableInterrupts(void) {
     USART_ITConfig(USART1, USART_IT_TC,   DISABLE);
     USART_ITConfig(USART1, USART_IT_RXNE, DISABLE);
 }
 
 void uart_clearRxInterrupts(){}
 
-void uart_clearTxInterrupts() {
+void uart_clearTxInterrupts(void) {
     USART_ClearFlag(USART1, USART_FLAG_TC);
 }
 
@@ -96,19 +96,19 @@ void uart_writeByte(uint8_t byteToWrite) {
     USART_SendData(USART1,(uint16_t)byteToWrite);
 }
 
-uint8_t uart_readByte() {
+uint8_t uart_readByte(void) {
     return (uint8_t)USART_ReceiveData(USART1);
 }
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
     uart_clearTxInterrupts();
     uart_vars.txCb();
     return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
     uart_vars.rxCb();
     return DO_NOT_KICK_SCHEDULER;
 }

--- a/bsp/boards/openmote-b/debugpins.c
+++ b/bsp/boards/openmote-b/debugpins.c
@@ -34,7 +34,7 @@ void bspDBpinToggle(uint32_t base,uint8_t ui8Pin);
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    GPIOPinTypeGPIOOutput(BSP_PINA_BASE, BSP_PINA_4 | BSP_PINA_5);
    GPIOPinTypeGPIOOutput(BSP_PIND_BASE, BSP_PIND_3 | BSP_PIND_2 | BSP_PIND_1 | BSP_PIND_0);
 
@@ -43,68 +43,68 @@ void debugpins_init() {
 }
 
 // PA4
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    bspDBpinToggle(BSP_PINA_BASE, BSP_PINA_4);
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
     GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_4, 0);
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_4, BSP_PINA_4);
 }
 
 // PD3
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_3);
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_3, 0);
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_3, BSP_PIND_3);
 }
 
 // PD2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_2);
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_2, 0);
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_2, BSP_PIND_2);
 }
 
 // PD1
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE,BSP_PIND_1);
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_1, 0);
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_1, BSP_PIND_1);
 }
 
 // PA5
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
 	bspDBpinToggle(BSP_PINA_BASE, BSP_PINA_5);
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
 	GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_5, 0);
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
 	GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_5, BSP_PINA_5);
 }
 
 // PD0
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_0);
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_0, 0);
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_0, BSP_PIND_0);
 }
 

--- a/bsp/boards/openmote-b/leds.c
+++ b/bsp/boards/openmote-b/leds.c
@@ -39,83 +39,83 @@ void bspLedToggle(uint8_t ui8Leds);
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
     GPIOPinTypeGPIOOutput(BSP_LED_BASE, BSP_LED_ALL);
 	GPIOPinWrite(BSP_LED_BASE, BSP_LED_ALL, BSP_LED_ALL);
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
 	bspLedSet(BSP_LED_1);
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
 	bspLedClear(BSP_LED_1);
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
 	bspLedToggle(BSP_LED_1);
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
 	  uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_1);
 	  return (uint8_t)(ui32Toggle & BSP_LED_1)>>4;
 }
 
 // orange
-void    leds_sync_on() {
+void    leds_sync_on(void) {
 	bspLedSet(BSP_LED_2);
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
 	bspLedClear(BSP_LED_2);
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
 	bspLedToggle(BSP_LED_2);
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
     return (uint8_t)(ui32Toggle & BSP_LED_2)>>5;
 }
 
 // green
-void    leds_radio_on() {
+void    leds_radio_on(void) {
 	bspLedSet(BSP_LED_4);
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
 	bspLedClear(BSP_LED_4);
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
 	bspLedToggle(BSP_LED_4);
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
 	return (uint8_t)(ui32Toggle & BSP_LED_4)>>7;
 }
 
 // yellow
-void    leds_debug_on() {
+void    leds_debug_on(void) {
 	bspLedSet(BSP_LED_3);
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
 	bspLedClear(BSP_LED_3);
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
 	bspLedToggle(BSP_LED_3);
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_3);
 	return (uint8_t)(ui32Toggle & BSP_LED_3)>>6;
 }
 
 // all
-void leds_all_on() {
+void leds_all_on(void) {
 	bspLedSet(BSP_LED_ALL);
 }
-void leds_all_off() {
+void leds_all_off(void) {
 	bspLedClear(BSP_LED_ALL);
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
 	bspLedToggle(BSP_LED_ALL);
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    
@@ -130,7 +130,7 @@ void leds_error_blink() {
    }
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t i;
    volatile uint16_t delay;
    
@@ -154,7 +154,7 @@ void leds_circular_shift() {
    }
 }
 
-void leds_increment() {
+void leds_increment(void) {
   uint8_t i;
    volatile uint16_t delay;
    

--- a/bsp/boards/openmote-b/radio.c
+++ b/bsp/boards/openmote-b/radio.c
@@ -60,7 +60,7 @@ void     radio_isr_internal(void);
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
    
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
@@ -164,7 +164,7 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
    
@@ -202,11 +202,11 @@ void radio_setFrequency(uint8_t frequency) {
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    //radio_on();
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
@@ -249,7 +249,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
@@ -265,7 +265,7 @@ void radio_txEnable() {
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    PORT_TIMER_WIDTH count;
    
    // change state
@@ -289,7 +289,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
@@ -305,7 +305,7 @@ void radio_rxEnable() {
    radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    //empty buffer before receiving
    //CC2538_RF_CSP_ISFLUSHRX();
    
@@ -429,7 +429,7 @@ the scheduler will always be kicked in after servicing an interrupt. This
 behaviour can be changed by modifying the SLEEPEXIT field in the SYSCTRL
 regiser (see page 131 of the CC2538 manual).
 */
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
    return DO_NOT_KICK_SCHEDULER;
 }
 

--- a/bsp/boards/openmote-b/uart.c
+++ b/bsp/boards/openmote-b/uart.c
@@ -45,7 +45,7 @@ static void uart_isr_private(void);
 
 //=========================== public ==========================================
 
-void uart_init() { 
+void uart_init(void) { 
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    
@@ -145,7 +145,7 @@ static void uart_isr_private(void){
 	debugpins_isr_clr();
 }
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    if (uart_vars.txCb != NULL) {
        uart_vars.txCb();
@@ -153,7 +153,7 @@ kick_scheduler_t uart_tx_isr() {
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    if (uart_vars.rxCb != NULL) {
        uart_vars.rxCb();

--- a/bsp/boards/openmote-cc2538/debugpins.c
+++ b/bsp/boards/openmote-cc2538/debugpins.c
@@ -34,7 +34,7 @@ void bspDBpinToggle(uint32_t base,uint8_t ui8Pin);
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    GPIOPinTypeGPIOOutput(BSP_PINA_BASE, BSP_PINA_4 | BSP_PINA_5);
    GPIOPinTypeGPIOOutput(BSP_PIND_BASE, BSP_PIND_3 | BSP_PIND_2 | BSP_PIND_1 | BSP_PIND_0);
 
@@ -43,68 +43,68 @@ void debugpins_init() {
 }
 
 // PA4
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    bspDBpinToggle(BSP_PINA_BASE, BSP_PINA_4);
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
     GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_4, 0);
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_4, BSP_PINA_4);
 }
 
 // PD3
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_3);
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_3, 0);
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_3, BSP_PIND_3);
 }
 
 // PD2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_2);
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_2, 0);
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_2, BSP_PIND_2);
 }
 
 // PD1
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE,BSP_PIND_1);
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_1, 0);
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_1, BSP_PIND_1);
 }
 
 // PA5
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
 	bspDBpinToggle(BSP_PINA_BASE, BSP_PINA_5);
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
 	GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_5, 0);
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
 	GPIOPinWrite(BSP_PINA_BASE, BSP_PINA_5, BSP_PINA_5);
 }
 
 // PD0
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
 	bspDBpinToggle(BSP_PIND_BASE, BSP_PIND_0);
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_0, 0);
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
 	GPIOPinWrite(BSP_PIND_BASE, BSP_PIND_0, BSP_PIND_0);
 }
 

--- a/bsp/boards/openmote-cc2538/leds.c
+++ b/bsp/boards/openmote-cc2538/leds.c
@@ -39,83 +39,83 @@ void bspLedToggle(uint8_t ui8Leds);
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
     GPIOPinTypeGPIOOutput(BSP_LED_BASE, BSP_LED_ALL);
 	GPIOPinWrite(BSP_LED_BASE, BSP_LED_ALL, 0);
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
 	bspLedSet(BSP_LED_1);
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
 	bspLedClear(BSP_LED_1);
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
 	bspLedToggle(BSP_LED_1);
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
 	  uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_1);
 	  return (uint8_t)(ui32Toggle & BSP_LED_1)>>4;
 }
 
 // orange
-void    leds_sync_on() {
+void    leds_sync_on(void) {
 	bspLedSet(BSP_LED_2);
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
 	bspLedClear(BSP_LED_2);
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
 	bspLedToggle(BSP_LED_2);
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
     return (uint8_t)(ui32Toggle & BSP_LED_2)>>5;
 }
 
 // green
-void    leds_radio_on() {
+void    leds_radio_on(void) {
 	bspLedSet(BSP_LED_4);
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
 	bspLedClear(BSP_LED_4);
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
 	bspLedToggle(BSP_LED_4);
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
 	return (uint8_t)(ui32Toggle & BSP_LED_4)>>7;
 }
 
 // yellow
-void    leds_debug_on() {
+void    leds_debug_on(void) {
 	bspLedSet(BSP_LED_3);
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
 	bspLedClear(BSP_LED_3);
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
 	bspLedToggle(BSP_LED_3);
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
 	uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_3);
 	return (uint8_t)(ui32Toggle & BSP_LED_3)>>6;
 }
 
 // all
-void leds_all_on() {
+void leds_all_on(void) {
 	bspLedSet(BSP_LED_ALL);
 }
-void leds_all_off() {
+void leds_all_off(void) {
 	bspLedClear(BSP_LED_ALL);
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
 	bspLedToggle(BSP_LED_ALL);
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    
@@ -130,7 +130,7 @@ void leds_error_blink() {
    }
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t i;
    volatile uint16_t delay;
    
@@ -154,7 +154,7 @@ void leds_circular_shift() {
    }
 }
 
-void leds_increment() {
+void leds_increment(void) {
   uint8_t i;
    volatile uint16_t delay;
    

--- a/bsp/boards/openmote-cc2538/radio.c
+++ b/bsp/boards/openmote-cc2538/radio.c
@@ -60,7 +60,7 @@ void     radio_isr_internal(void);
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
    
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
@@ -164,7 +164,7 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
    
@@ -202,11 +202,11 @@ void radio_setFrequency(uint8_t frequency) {
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    //radio_on();
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
@@ -249,7 +249,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
@@ -265,7 +265,7 @@ void radio_txEnable() {
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    PORT_TIMER_WIDTH count;
    
    // change state
@@ -289,7 +289,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
@@ -305,7 +305,7 @@ void radio_rxEnable() {
    radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    //empty buffer before receiving
    //CC2538_RF_CSP_ISFLUSHRX();
    
@@ -429,7 +429,7 @@ the scheduler will always be kicked in after servicing an interrupt. This
 behaviour can be changed by modifying the SLEEPEXIT field in the SYSCTRL
 regiser (see page 131 of the CC2538 manual).
 */
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
    return DO_NOT_KICK_SCHEDULER;
 }
 

--- a/bsp/boards/openmote-cc2538/uart.c
+++ b/bsp/boards/openmote-cc2538/uart.c
@@ -45,7 +45,7 @@ static void uart_isr_private(void);
 
 //=========================== public ==========================================
 
-void uart_init() { 
+void uart_init(void) { 
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    
@@ -145,7 +145,7 @@ static void uart_isr_private(void){
 	debugpins_isr_clr();
 }
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    if (uart_vars.txCb != NULL) {
        uart_vars.txCb();
@@ -153,7 +153,7 @@ kick_scheduler_t uart_tx_isr() {
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    if (uart_vars.rxCb != NULL) {
        uart_vars.rxCb();

--- a/bsp/boards/openmotestm/debugpins.c
+++ b/bsp/boards/openmotestm/debugpins.c
@@ -14,7 +14,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
   
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC , ENABLE);
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA , ENABLE);
@@ -52,81 +52,81 @@ void debugpins_frame_toggle(){
     
     GPIOC->ODR ^= 0X0020;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
     
     GPIOC->ODR &= ~0X0020;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
     
     GPIOC->ODR |=  0X0020;
 }   
 
 // PA.7
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
     
     GPIOA->ODR ^=  0X0080;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
     
     GPIOA->ODR &= ~0X0080;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
     
     GPIOA->ODR |=  0X0080;
 }
 
 // PA.5
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
     
     GPIOA->ODR ^=  0X0020;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
     
     GPIOA->ODR &= ~0X0020;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
     
     GPIOA->ODR |=  0X0020;
 }
 
 // PA.6
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
     
     GPIOA->ODR ^=  0X0040;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
     
     GPIOA->ODR &= ~0X0040;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
     
     GPIOA->ODR |= 0X0040;
 }
 
 // PC.1
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
     
     GPIOC->ODR ^=  0X0002;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
     
     GPIOC->ODR &= ~0X0002;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
     
     GPIOC->ODR |= 0X0002;
 }
 
 // PC.0
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
     
     GPIOC->ODR ^=  0X0001;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
     
     GPIOC->ODR &= ~0X0001;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
     
     GPIOC->ODR |=  0X0001;
 }

--- a/bsp/boards/openmotestm/leds.c
+++ b/bsp/boards/openmotestm/leds.c
@@ -16,7 +16,7 @@ void Delay(void);
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
     
     // Enable GPIOC clock
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC , ENABLE);
@@ -29,17 +29,17 @@ void leds_init() {
 }
 
 // red
-void leds_error_on() {
+void leds_error_on(void) {
     
     GPIOC->ODR |= 0X0040;
 }
 
-void leds_error_off() {
+void leds_error_off(void) {
     
     GPIOC->ODR &= ~0X0040;
 }
 
-void leds_error_toggle() {
+void leds_error_toggle(void) {
     
    GPIOC->ODR ^= 0X0040;
 }
@@ -65,22 +65,22 @@ void leds_error_blink(){
 }
 
 // green
-void leds_radio_on() {
+void leds_radio_on(void) {
     
     GPIOC->ODR |= 0X0080;
 }
 
-void leds_radio_off() {
+void leds_radio_off(void) {
     
     GPIOC->ODR &= ~0X0080;
 }
 
-void leds_radio_toggle() {
+void leds_radio_toggle(void) {
     
     GPIOC->ODR ^= 0X0080;
 }
 
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
     
     u8 bitstatus = 0x00;
     if ((GPIOC->ODR & 0X0080) != (u32)0) {
@@ -92,22 +92,22 @@ uint8_t leds_radio_isOn() {
 }
 
 // blue
-void leds_sync_on() {
+void leds_sync_on(void) {
     
     GPIOC->ODR |= 0X0400;
 }
 
-void leds_sync_off() {
+void leds_sync_off(void) {
     
     GPIOC->ODR &= ~0X0400;
 }
 
-void leds_sync_toggle() {
+void leds_sync_toggle(void) {
     
     GPIOC->ODR ^= 0X0400;
 }
 
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
     
     u8 bitstatus = 0x00;
     if ((GPIOC->ODR & 0X0400) != (u32)0){
@@ -119,7 +119,7 @@ uint8_t leds_sync_isOn() {
 }
 
 // yellow
-void leds_debug_on() {
+void leds_debug_on(void) {
     
     GPIOC->ODR |= 0X0800;  
 }
@@ -145,20 +145,20 @@ uint8_t leds_debug_isOn(){
     return bitstatus;
 }
 
-void leds_all_on() {
+void leds_all_on(void) {
     
     GPIOC->ODR |= 0X0CC0;
 }
 
-void leds_all_off() {
+void leds_all_off(void) {
     GPIOC->ODR &= ~0X0CC0;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
     
     GPIOC->ODR ^= 0X0CC0;
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
     
     GPIOC->ODR ^= 0X0040;
     Delay();
@@ -178,7 +178,7 @@ void leds_circular_shift() {
     Delay();
 }
 
-void leds_increment() {
+void leds_increment(void) {
     
 }
 

--- a/bsp/boards/openmotestm/sctimer.c
+++ b/bsp/boards/openmotestm/sctimer.c
@@ -38,7 +38,7 @@ sctimer_vars_t sctimer_vars;
 
 //===== admin
 
-void sctimer_init() {
+void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
     //enable BKP and PWR, Clock
@@ -85,7 +85,7 @@ void sctimer_set_callback(sctimer_cbt cb){
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH sctimer_readCounter() {
+PORT_RADIOTIMER_WIDTH sctimer_readCounter(void) {
     uint32_t counter;
     RTC_WaitForSynchro();
     counter = RTC_GetCounter();
@@ -180,12 +180,12 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_enable() {
+void sctimer_enable(void) {
     RTC_ClearFlag(RTC_IT_ALR);
     RTC_ITConfig(RTC_IT_ALR, ENABLE);
 }
 
-void sctimer_disable() {
+void sctimer_disable(void) {
     RTC_ITConfig(RTC_IT_ALR, DISABLE);
 }
 
@@ -193,7 +193,7 @@ void sctimer_disable() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
     if (sctimer_vars.sctimer_cb!=NULL) {
         
         RCC_Wakeup();

--- a/bsp/boards/openmotestm/spi.c
+++ b/bsp/boards/openmotestm/spi.c
@@ -41,7 +41,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
     memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -189,7 +189,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
     // save the byte just received in the RX buffer
     switch (spi_vars.returnType) {

--- a/bsp/boards/openmotestm/uart.c
+++ b/bsp/boards/openmotestm/uart.c
@@ -32,7 +32,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
     
     // reset local variables
     memset(&uart_vars,0,sizeof(uart_vars_t));
@@ -120,7 +120,7 @@ void uart_writeByte(uint8_t byteToWrite) {
     }
 }
 
-uint8_t uart_readByte() {
+uint8_t uart_readByte(void) {
     
     uint16_t temp;
     temp = USART_ReceiveData(USART1);
@@ -129,13 +129,13 @@ uint8_t uart_readByte() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
     
     uart_vars.txCb();
     return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
     
     uart_vars.rxCb();
     return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/scum/board.c
+++ b/bsp/boards/scum/board.c
@@ -28,7 +28,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
     uint8_t eui[8];
 
     // initialize bsp modules
@@ -40,11 +40,11 @@ void board_init() {
     eui64_get(eui);
 }
 
-void board_sleep() {
+void board_sleep(void) {
     // not sure how to enter a sleep mode
 }
 
-void board_reset() {
+void board_reset(void) {
     // not sure how the reset is triggered
 }
 

--- a/bsp/boards/scum/bsp_timer.c
+++ b/bsp/boards/scum/bsp_timer.c
@@ -33,7 +33,7 @@ bsp_timer_vars_t bsp_timer_vars;
 This functions starts the timer, i.e. the counter increments, but doesn't set
 any compare registers, so no interrupt will fire.
 */
-void bsp_timer_init() {
+void bsp_timer_init(void) {
    
     // clear local variables
     memset(&bsp_timer_vars,0,sizeof(bsp_timer_vars_t));
@@ -59,7 +59,7 @@ void bsp_timer_set_callback(bsp_timer_cbt cb) {
 This function does not stop the timer, it rather resets the value of the
 counter, and cancels a possible pending compare event.
 */
-void bsp_timer_reset() {
+void bsp_timer_reset(void) {
     // record last timer compare value
     bsp_timer_vars.last_compare_value   = 0;
 }
@@ -106,7 +106,7 @@ void bsp_timer_scheduleIn(PORT_TIMER_WIDTH delayTicks) {
 /**
 \brief Cancel a running compare.
 */
-void bsp_timer_cancel_schedule() {
+void bsp_timer_cancel_schedule(void) {
     RFTIMER_REG__COMPARE0_CONTROL   = 0x00;
 }
 
@@ -115,7 +115,7 @@ void bsp_timer_cancel_schedule() {
 
 \returns The current value of the timer's counter.
 */
-PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
+PORT_TIMER_WIDTH bsp_timer_get_currentValue(void) {
     return TIMER_COUTER_CONVERT_500K_TO_32K(RFTIMER_REG__COUNTER);
 }
 
@@ -123,7 +123,7 @@ PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t bsp_timer_isr() {
+kick_scheduler_t bsp_timer_isr(void) {
     
     // call the callback
     bsp_timer_vars.cb();

--- a/bsp/boards/scum/debugpins.c
+++ b/bsp/boards/scum/debugpins.c
@@ -17,78 +17,78 @@ To be implemented after issue: SCUM-25
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_task_set() {
+void debugpins_task_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }
 
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
     // empty for now, see https://openwsn.atlassian.net/browse/SCUM-25
 }

--- a/bsp/boards/scum/leds.c
+++ b/bsp/boards/scum/leds.c
@@ -16,77 +16,77 @@
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
     GPIO_REG__OUTPUT    &= ~0x0F;    // GPIO_REG__OUTPUT = 0bxxxx0000, all LEDs off
 }
 
 // 0 <H17>
-void    leds_error_on() {
+void    leds_error_on(void) {
     GPIO_REG__OUTPUT    |=  0x01;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
     GPIO_REG__OUTPUT    &= ~0x01;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
     GPIO_REG__OUTPUT    ^=  0x01;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
     return (uint8_t)(GPIO_REG__OUTPUT & 0x01);
 }
 
 // 1 <K15>
-void    leds_radio_on() {
+void    leds_radio_on(void) {
     GPIO_REG__OUTPUT    |=  0x02;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
     GPIO_REG__OUTPUT    &= ~0x02;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
     GPIO_REG__OUTPUT    ^=  0x02;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
     return (uint8_t)(GPIO_REG__OUTPUT & 0x02)>>1;
 }
 
 // 2 <J13>
-void    leds_sync_on() {
+void    leds_sync_on(void) {
     GPIO_REG__OUTPUT    |=  0x04;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
     GPIO_REG__OUTPUT    &= ~0x04;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
     GPIO_REG__OUTPUT    ^=  0x04;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
     return (uint8_t)(GPIO_REG__OUTPUT & 0x04)>>2;
 }
 
 // 3 <N14>
-void    leds_debug_on() {
+void    leds_debug_on(void) {
     GPIO_REG__OUTPUT    |=  0x08;
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
     GPIO_REG__OUTPUT    &= ~0x08;
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
     GPIO_REG__OUTPUT    ^=  0x08;
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
     return (uint8_t)(GPIO_REG__OUTPUT & 0x08)>>3;
 }
 
-void leds_all_on() {
+void leds_all_on(void) {
     GPIO_REG__OUTPUT    |=  0x0F;
 }
-void leds_all_off() {
+void leds_all_off(void) {
     GPIO_REG__OUTPUT    &= ~0x0F;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
     GPIO_REG__OUTPUT    ^=  0x0F;
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
     uint8_t i;
     volatile uint16_t delay;
     // turn all LEDs off
@@ -99,7 +99,7 @@ void leds_error_blink() {
     }
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
     uint8_t temp_leds;
     if ((GPIO_REG__OUTPUT & 0x0F)==0) {         // if no LEDs on, switch on first one
         GPIO_REG__OUTPUT    |= 0x01;
@@ -114,7 +114,7 @@ void leds_circular_shift() {
     GPIO_REG__OUTPUT    &= ~(~temp_leds & 0x0F);   // switch off the leds marked '0' in temp_leds
 }
 
-void leds_increment() {
+void leds_increment(void) {
    uint8_t led_counter;
    led_counter           = ((GPIO_REG__OUTPUT & 0x0f)+1);
    GPIO_REG__OUTPUT     &= ~0x0f;                   //all LEDs off

--- a/bsp/boards/scum/radio.c
+++ b/bsp/boards/scum/radio.c
@@ -39,7 +39,7 @@ radio_vars_t radio_vars;
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
 
     // clear variables
     memset(&radio_vars,0,sizeof(radio_vars_t));
@@ -86,7 +86,7 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
     // reset SCuM radio module
     PORT_PIN_RADIO_RESET_LOW();
 }
@@ -104,12 +104,12 @@ void radio_setFrequency(uint8_t frequency) {
     radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
     // clear reset pin
     RFCONTROLLER_REG__CONTROL   &= ~RX_RESET;
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
     // change state
     radio_vars.state            = RADIOSTATE_TURNING_OFF;
 
@@ -161,7 +161,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
 
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
     // change state
     radio_vars.state = RADIOSTATE_ENABLING_TX;
 
@@ -175,7 +175,7 @@ void radio_txEnable() {
     radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
 
     // change state
     RFCONTROLLER_REG__CONTROL = TX_SEND;
@@ -187,7 +187,7 @@ void radio_rxPacket_prepare(void){
     DMA_REG__RF_RX_ADDR         = &(radio_vars.radio_rx_buffer[0]);
 }
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
     
     // change state
     radio_vars.state            = RADIOSTATE_ENABLING_RX;
@@ -215,7 +215,7 @@ void radio_rxEnable_scum(void){
     radio_vars.state            = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
     // nothing to do
 }
 
@@ -245,7 +245,7 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
     
     PORT_TIMER_WIDTH capturedTime;
     

--- a/bsp/boards/scum/radiotimer.c
+++ b/bsp/boards/scum/radiotimer.c
@@ -31,7 +31,7 @@ radiotimer_vars_t radiotimer_vars;
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
     // clear local variables
     memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
 }
@@ -69,7 +69,7 @@ void radiotimer_start(PORT_RADIOTIMER_WIDTH period) {
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH radiotimer_getValue() {
+PORT_RADIOTIMER_WIDTH radiotimer_getValue(void) {
     return TIMER_COUTER_CONVERT_500K_TO_32K(RFTIMER_REG__COUNTER);
 }
 
@@ -77,7 +77,7 @@ void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period) {
     RFTIMER_REG__MAX_COUNT          = TIMER_COUTER_CONVERT_32K_TO_500K(period);
 }
 
-PORT_RADIOTIMER_WIDTH radiotimer_getPeriod() {
+PORT_RADIOTIMER_WIDTH radiotimer_getPeriod(void) {
     return TIMER_COUTER_CONVERT_500K_TO_32K(RFTIMER_REG__MAX_COUNT);
 }
 
@@ -222,7 +222,7 @@ void radiotimer_schedule(PORT_RADIOTIMER_WIDTH offset) {
                                       RFTIMER_COMPARE_INTERRUPT_ENABLE;
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
     // disable compare interrupt
     RFTIMER_REG__COMPARE2_CONTROL = 0x00;
 }
@@ -230,7 +230,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
+PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime(void) {
     return TIMER_COUTER_CONVERT_500K_TO_32K(RFTIMER_REG__COUNTER);
 }
 
@@ -238,7 +238,7 @@ PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t radiotimer_isr() {
+kick_scheduler_t radiotimer_isr(void) {
     PORT_RADIOTIMER_WIDTH interrupt_flag = RFTIMER_REG__INT;
     debugpins_isr_set();
 #ifdef SLOT_FSM_IMPLEMENTATION_MULTIPLE_TIMER_INTERRUPT

--- a/bsp/boards/scum/uart.c
+++ b/bsp/boards/scum/uart.c
@@ -25,7 +25,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
     // reset local variables
     memset(&uart_vars,0,sizeof(uart_vars_t));
 }
@@ -67,14 +67,14 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
     if (uart_vars.txCb != NULL){
         uart_vars.txCb();
     }
     return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
     if (uart_vars.rxCb != NULL){
         uart_vars.rxCb();
     }

--- a/bsp/boards/silabs-ezr32wg/bsp_timer.c
+++ b/bsp/boards/silabs-ezr32wg/bsp_timer.c
@@ -39,7 +39,7 @@ void bsp_timer_isr_private(void);
  This functions starts the timer, i.e. the counter increments, but doesn't set
  any compare registers, so no interrupt will fire.
  */
-void bsp_timer_init() {
+void bsp_timer_init(void) {
         
 	// clear local variables
 	memset(&bsp_timer_vars, 0, sizeof(bsp_timer_vars_t));
@@ -105,7 +105,7 @@ void bsp_timer_set_callback(bsp_timer_cbt cb) {
  This function does not stop the timer, it rather resets the value of the
  counter, and cancels a possible pending compare event.
  */
-void bsp_timer_reset() {
+void bsp_timer_reset(void) {
 	//reset compare
 	
 	bsp_timer_vars.initiated=FALSE;
@@ -172,7 +172,7 @@ void bsp_timer_scheduleIn(PORT_TIMER_WIDTH delayTicks) {
 /**
  \brief Cancel a running compare.
  */
-void bsp_timer_cancel_schedule() {
+void bsp_timer_cancel_schedule(void) {
 
         LETIMER_IntDisable(LETIMER0, LETIMER_IEN_COMP1);
         LETIMER_Enable(LETIMER0, false);
@@ -183,7 +183,7 @@ void bsp_timer_cancel_schedule() {
 
  \returns The current value of the timer's counter.
  */
-PORT_TIMER_WIDTH bsp_timer_get_currentValue() {
+PORT_TIMER_WIDTH bsp_timer_get_currentValue(void) {
 	return LETIMER_CounterGet(LETIMER0); //SleepModeTimerCountGet();
 }
 
@@ -197,7 +197,7 @@ void bsp_timer_isr_private(void) {
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t bsp_timer_isr() {
+kick_scheduler_t bsp_timer_isr(void) {
 
 	// call the callback
 	bsp_timer_vars.cb();

--- a/bsp/boards/silabs-ezr32wg/debugpins.c
+++ b/bsp/boards/silabs-ezr32wg/debugpins.c
@@ -28,7 +28,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
 	//enable clock for this peripheral
 	CMU_ClockEnable(cmuClock_HFPER, true);
 	CMU_ClockEnable(cmuClock_GPIO, true);
@@ -43,82 +43,82 @@ void debugpins_init() {
 }
 
 // PD1
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
 	GPIO_PinOutToggle(gpioPortC, GPIO_PORT_FRAME);
 }
 
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
 	GPIO_PinOutClear(gpioPortC, GPIO_PORT_FRAME);
 }
 
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
 	GPIO_PinOutSet(gpioPortC, GPIO_PORT_FRAME);
 }
 
 // PD3
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
 	GPIO_PinOutToggle(gpioPortC, GPIO_PORT_SLOT);
 }
 
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
 	GPIO_PinOutClear(gpioPortC, GPIO_PORT_SLOT);
 }
 
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
 	GPIO_PinOutSet(gpioPortC, GPIO_PORT_SLOT);
 }
 
 // PD2
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
 	GPIO_PinOutToggle(gpioPortB, GPIO_PORT_FSM);
 }
 
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
 	GPIO_PinOutClear(gpioPortB, GPIO_PORT_FSM);
 }
 
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
 	GPIO_PinOutSet(gpioPortB, GPIO_PORT_FSM);
 }
 
 // PD1
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
 	GPIO_PinOutToggle(gpioPortE, GPIO_PORT_TASK);
 }
 
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
 	GPIO_PinOutClear(gpioPortE, GPIO_PORT_TASK);
 }
 
-void debugpins_task_set() {
+void debugpins_task_set(void) {
 	GPIO_PinOutSet(gpioPortE, GPIO_PORT_TASK);
 }
 
 // PA5
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
 	GPIO_PinOutToggle(gpioPortE, GPIO_PORT_ISR);
 }
 
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
 	GPIO_PinOutClear(gpioPortE, GPIO_PORT_ISR);
 }
 
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
 	GPIO_PinOutSet(gpioPortE, GPIO_PORT_ISR);
 }
 
 // PD0
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
 	GPIO_PinOutToggle(gpioPortF, GPIO_PORT_RADIO);
 
 }
 
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
 	GPIO_PinOutClear(gpioPortF, GPIO_PORT_RADIO);
 
 }
 
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
 	GPIO_PinOutSet(gpioPortF, GPIO_PORT_RADIO);
 }
 

--- a/bsp/boards/silabs-ezr32wg/leds.c
+++ b/bsp/boards/silabs-ezr32wg/leds.c
@@ -25,7 +25,7 @@
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
 	//enable clock for this peripheral
 	CMU_ClockEnable(cmuClock_HFPER, TRUE);
 	CMU_ClockEnable(cmuClock_GPIO, TRUE);
@@ -38,96 +38,96 @@ void leds_init() {
 }
 
 // red
-void leds_error_on() {
+void leds_error_on(void) {
 	GPIO_PinOutSet(gpioPortF, LEDS_PORT_ERROR);
 }
 
-void leds_error_off() {
+void leds_error_off(void) {
 	GPIO_PinOutClear(gpioPortF, LEDS_PORT_ERROR);
 }
 
-void leds_error_toggle() {
+void leds_error_toggle(void) {
 	GPIO_PinOutToggle(gpioPortF, LEDS_PORT_ERROR);
 }
 
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
 	return (uint8_t) (1 == GPIO_PinOutGet(gpioPortF, LEDS_PORT_ERROR));
 }
 
 // orange
-void leds_sync_on() {
+void leds_sync_on(void) {
 	GPIO_PinOutSet(gpioPortF, LEDS_PORT_SYNC);
 }
 
-void leds_sync_off() {
+void leds_sync_off(void) {
 	GPIO_PinOutClear(gpioPortF, LEDS_PORT_SYNC);
 }
 
-void leds_sync_toggle() {
+void leds_sync_toggle(void) {
 	GPIO_PinOutToggle(gpioPortF, LEDS_PORT_SYNC);
 }
 
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
 	return (uint8_t) (1 == GPIO_PinOutGet(gpioPortF, LEDS_PORT_SYNC));
 }
 
 // green
-void leds_radio_on() {
+void leds_radio_on(void) {
 	GPIO_PinOutSet(gpioPortF, LEDS_PORT_RADIO);
 }
 
-void leds_radio_off() {
+void leds_radio_off(void) {
 	GPIO_PinOutClear(gpioPortF, LEDS_PORT_RADIO);
 }
 
-void leds_radio_toggle() {
+void leds_radio_toggle(void) {
 	GPIO_PinOutToggle(gpioPortF, LEDS_PORT_RADIO);
 }
 
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
 	return (uint8_t) (1 == GPIO_PinOutGet(gpioPortF, LEDS_PORT_RADIO));
 }
 
 // yellow
-void leds_debug_on() {
+void leds_debug_on(void) {
 	GPIO_PinOutSet(gpioPortF, LEDS_PORT_DEBUG);
 }
 
-void leds_debug_off() {
+void leds_debug_off(void) {
 	GPIO_PinOutClear(gpioPortF, LEDS_PORT_DEBUG);
 }
 
-void leds_debug_toggle() {
+void leds_debug_toggle(void) {
 	GPIO_PinOutToggle(gpioPortF, LEDS_PORT_DEBUG);
 }
 
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
 	return (uint8_t) (1 == GPIO_PinOutGet(gpioPortF, LEDS_PORT_DEBUG));
 }
 
 // all
-void leds_all_on() {
+void leds_all_on(void) {
 	leds_radio_on();
 	leds_sync_on();
 	leds_debug_on();
 	leds_error_on();
 }
 
-void leds_all_off() {
+void leds_all_off(void) {
 	leds_radio_off();
 	leds_sync_off();
 	leds_debug_off();
 	leds_error_off();
 }
 
-void leds_all_toggle() {
+void leds_all_toggle(void) {
 	leds_radio_toggle();
 	leds_sync_toggle();
 	leds_debug_toggle();
 	leds_error_toggle();
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
 	uint8_t i;
 	volatile uint16_t delay;
 
@@ -144,12 +144,12 @@ void leds_error_blink() {
 	}
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
     //not implemented
 	return;
 }
 
-void leds_increment() {
+void leds_increment(void) {
 	//not implemented
 	return;
 }

--- a/bsp/boards/silabs-ezr32wg/radio.c
+++ b/bsp/boards/silabs-ezr32wg/radio.c
@@ -44,7 +44,7 @@ void radio_isr_internal(void);
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
 
 	// clear variables
 	memset(&radio_vars, 0, sizeof(radio_vars_t));
@@ -85,7 +85,7 @@ void radio_setEndFrameCb(radiotimer_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
 
 }
 
@@ -95,7 +95,7 @@ void radio_startTimer(PORT_TIMER_WIDTH period) {
 	radiotimer_start(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerValue() {
+PORT_TIMER_WIDTH radio_getTimerValue(void) {
 	return radiotimer_getValue();
 }
 
@@ -103,7 +103,7 @@ void radio_setTimerPeriod(PORT_TIMER_WIDTH period) {
 	radiotimer_setPeriod(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerPeriod() {
+PORT_TIMER_WIDTH radio_getTimerPeriod(void) {
 	return radiotimer_getPeriod();
 }
 
@@ -117,11 +117,11 @@ void radio_setFrequency(uint8_t frequency) {
 	radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
 
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
 
 	// change state
 	radio_vars.state = RADIOSTATE_TURNING_OFF;
@@ -150,7 +150,7 @@ void radio_loadPacket(uint8_t* packet, uint8_t len) {
 	radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
 
 	// change state
 	radio_vars.state = RADIOSTATE_ENABLING_TX;
@@ -166,7 +166,7 @@ void radio_txEnable() {
 	radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
 	PORT_TIMER_WIDTH count;
 
 	// change state
@@ -183,7 +183,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
 
 	// change state
 	radio_vars.state = RADIOSTATE_ENABLING_RX;
@@ -199,7 +199,7 @@ void radio_rxEnable() {
 	radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
 	//empty buffer before receiving
 
 	//enable radio interrupts
@@ -245,7 +245,7 @@ void radio_off(void) {
  to be processed). Otherwise, the CPU is kept in sleep mode without even
  reaching the main loop.
  */
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
 	return DO_NOT_KICK_SCHEDULER;
 }
 

--- a/bsp/boards/silabs-ezr32wg/radiotimer.c
+++ b/bsp/boards/silabs-ezr32wg/radiotimer.c
@@ -33,7 +33,7 @@ port_INLINE uint16_t get_real_counter(void);
 
 //===== admin
 
-void radiotimer_init() {
+void radiotimer_init(void) {
    // clear local variables
    memset(&radiotimer_vars,0,sizeof(radiotimer_vars_t));
    
@@ -79,7 +79,7 @@ void radiotimer_start(PORT_RADIOTIMER_WIDTH period) {
 
 //===== direct access
 
-PORT_RADIOTIMER_WIDTH radiotimer_getValue() {
+PORT_RADIOTIMER_WIDTH radiotimer_getValue(void) {
 	 PORT_RADIOTIMER_WIDTH value=0;
 	 //select period register in the selector so it can be read
          value = RTC->CNT;
@@ -92,7 +92,7 @@ void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period) {
         RTC_CompareSet(0, period);
 }
 
-PORT_RADIOTIMER_WIDTH radiotimer_getPeriod() {
+PORT_RADIOTIMER_WIDTH radiotimer_getPeriod(void) {
 	PORT_RADIOTIMER_WIDTH period=0;
          
 
@@ -112,7 +112,7 @@ void radiotimer_schedule(PORT_RADIOTIMER_WIDTH offset) {
         
 }
 
-void radiotimer_cancel() {
+void radiotimer_cancel(void) {
         RTC_IntDisable(RTC_IEN_COMP0);
         RTC_IntDisable(RTC_IEN_COMP1);
         //RTC_CompareSet(0, radiotimer_vars.currentSlotPeriod);
@@ -125,7 +125,7 @@ void radiotimer_cancel() {
 
 //===== capture
 
-port_INLINE PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime() {
+port_INLINE PORT_RADIOTIMER_WIDTH radiotimer_getCapturedTime(void) {
 	 PORT_RADIOTIMER_WIDTH value=0;
          value = RTC->CNT;
      return (PORT_RADIOTIMER_WIDTH)value;
@@ -149,7 +149,7 @@ void radiotimer_isr_private(){
 }
 
 
-kick_scheduler_t radiotimer_isr() {
+kick_scheduler_t radiotimer_isr(void) {
   /* Clear interrupt source */
     // RTC_IntClear(RTC_IFC_COMP0);
     // Compare

--- a/bsp/boards/silabs-ezr32wg/uart.c
+++ b/bsp/boards/silabs-ezr32wg/uart.c
@@ -53,7 +53,7 @@ static void uart_isr_private(void);
 
 //=========================== public ==========================================
 
-void uart_init() { 
+void uart_init(void) { 
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    /* Enable peripheral clocks */
@@ -177,7 +177,7 @@ static void uart_isr_private(void){
 	debugpins_isr_clr();
 }
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
 /*   uart_clearTxInterrupts();
    if (uart_vars.txCb != NULL) {
        uart_vars.txCb();
@@ -187,7 +187,7 @@ kick_scheduler_t uart_tx_isr() {
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
  /*  uart_clearRxInterrupts();
    if (uart_vars.rxCb != NULL) {
        uart_vars.rxCb();

--- a/bsp/boards/telosb/board.c
+++ b/bsp/boards/telosb/board.c
@@ -37,7 +37,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    // disable watchdog timer
    WDTCTL     =  WDTPW + WDTHOLD;
    
@@ -62,11 +62,11 @@ void board_init() {
    __bis_SR_register(GIE);
 }
 
-void board_sleep() {
+void board_sleep(void) {
    __bis_SR_register(GIE+LPM0_bits);             // sleep, but leave ACLK on
 }
 
-void board_reset() {
+void board_reset(void) {
    WDTCTL = (WDTPW+0x1200) + WDTHOLD; // writing a wrong watchdog password to causes handler to reset
 }
 

--- a/bsp/boards/telosb/debugpins.c
+++ b/bsp/boards/telosb/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    P6DIR |=  0x40;      // frame     [P6.6]
    P6DIR |=  0x80;      // slot      [P6.7]
    P2DIR |=  0x08;      // fsm       [P2.3]
@@ -27,57 +27,57 @@ void debugpins_init() {
 }
 
 // P6.6
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    P6OUT ^=  0x40;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
    P6OUT &= ~0x40;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    P6OUT |=  0x40;
 }
 
 // P6.7
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
    P6OUT ^=  0x80;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
    P6OUT &= ~0x80;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
    P6OUT |=  0x80;
 }
 
 // P2.3
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
    P2OUT ^=  0x08;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
    P2OUT &= ~0x08;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
    P2OUT |=  0x08;
 }
 
 // P2.6
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
    P2OUT ^=  0x40;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
    P2OUT &= ~0x40;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
    P2OUT |=  0x40;
 }
 
 // P6.0
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
    P6OUT ^=  0x01;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
    P6OUT &= ~0x01;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
    P6OUT |=  0x01;
 }
 
@@ -104,13 +104,13 @@ void debugpins_isruartrx_set(void) {
 }
 
 // P6.1
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
    P6OUT ^=  0x02;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
    P6OUT &= ~0x02;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
    P6OUT |=  0x02;
 }
 

--- a/bsp/boards/telosb/eui64.c
+++ b/bsp/boards/telosb/eui64.c
@@ -98,7 +98,7 @@ void eui64_get(uint8_t* addressToWrite) {    // >= 6000us
 
 // admin
 
-uint8_t ow_reset() {              // >= 960us 
+uint8_t ow_reset(void) {              // >= 960us 
    int present;
    owpin_output_low();
    delay_us(OW_DLY_H);            // t_RSTL
@@ -118,7 +118,7 @@ void ow_write_byte(uint8_t byte) {// >= 560us
    }
 }
 
-uint8_t ow_read_byte() {          // >= 560us
+uint8_t ow_read_byte(void) {          // >= 560us
    uint8_t byte = 0;
    uint8_t bit;
    for( bit=0x01; bit!=0; bit<<=1 ) {
@@ -139,7 +139,7 @@ void ow_write_bit(int is_one) {   // >= 70us
    }
 }
 
-uint8_t ow_read_bit() {           // >= 70us
+uint8_t ow_read_bit(void) {           // >= 70us
    int bit;
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_RL
@@ -150,14 +150,14 @@ uint8_t ow_read_bit() {           // >= 70us
    return bit;
 }
 
-void ow_write_bit_one() {         // >= 70us
+void ow_write_bit_one(void) {         // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_W1L
    owpin_output_high();
    delay_us(OW_DLY_B);            // t_SLOT - t_W1L
 }
 
-void ow_write_bit_zero() {        // >= 70us
+void ow_write_bit_zero(void) {        // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_C);            // t_W0L
    owpin_output_high();
@@ -196,23 +196,23 @@ void delay_us(uint16_t delay) {
 
 //===== pin
 
-void    owpin_init() {
+void    owpin_init(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
    P2OUT &= ~PIN_1WIRE;           // pull low
 }
 
-void    owpin_output_low() {
+void    owpin_output_low(void) {
    P2DIR |=  PIN_1WIRE;           // set as output
 }
 
-void    owpin_output_high() {
+void    owpin_output_high(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-void    owpin_prepare_read() {
+void    owpin_prepare_read(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-uint8_t owpin_read() {
+uint8_t owpin_read(void) {
    return (P2IN & PIN_1WIRE);
 }

--- a/bsp/boards/telosb/leds.c
+++ b/bsp/boards/telosb/leds.c
@@ -15,25 +15,25 @@
 
 //=========================== public ==========================================
 
-void    leds_init() {
+void    leds_init(void) {
    P5DIR     |=  0x70;                           // P5DIR = 0bx111xxxx for LEDs
    P5OUT     |=  0x70;                           // P2OUT = 0bx111xxxx, all LEDs off
 }
 
 // red = LED1 = P5.4
-void    leds_error_on() {
+void    leds_error_on(void) {
    P5OUT     &= ~0x10;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    P5OUT     |=  0x10;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    P5OUT     ^=  0x10;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
    return (uint8_t)(~P5OUT & 0x10)>>4;
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    // turn all LEDs off
@@ -47,58 +47,58 @@ void leds_error_blink() {
 }
 
 // green = LED2 = P5.5
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    P5OUT     &= ~0x20;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    P5OUT     |=  0x20;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    P5OUT     ^=  0x20;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
    return (uint8_t)(~P5OUT & 0x20)>>5;
 }
 
 // blue = LED3 = P5.6
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    P5OUT     &= ~0x40;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    P5OUT     |=  0x40;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    P5OUT     ^=  0x40;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    return (uint8_t)(~P5OUT & 0x40)>>6;
 }
 
-void    leds_debug_on() {
+void    leds_debug_on(void) {
    // TelosB doesn't have a debug LED :(
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
    // TelosB doesn't have a debug LED :(
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
    // TelosB doesn't have a debug LED :(
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    // TelosB doesn't have a debug LED :(
    return 0;
 }
 
-void    leds_all_on() {
+void    leds_all_on(void) {
    P5OUT     &= ~0x70;
 }
-void    leds_all_off() {
+void    leds_all_off(void) {
    P5OUT     |=  0x70;
 }
-void    leds_all_toggle() {
+void    leds_all_toggle(void) {
    P5OUT     ^=  0x70;
 }
 
-void    leds_circular_shift() {
+void    leds_circular_shift(void) {
    uint8_t leds_on;
    // get LED state
    leds_on  = (~P5OUT & 0x70) >> 4;
@@ -118,7 +118,7 @@ void    leds_circular_shift() {
    P5OUT &= ~( leds_on & 0x70);                  // switch off the leds marked '0' in leds_on
 }
 
-void    leds_increment() {
+void    leds_increment(void) {
    uint8_t leds_on;
    // get LED state
    leds_on  = (~P5OUT & 0x70) >> 4;

--- a/bsp/boards/telosb/sctimer.c
+++ b/bsp/boards/telosb/sctimer.c
@@ -110,7 +110,7 @@ void sctimer_disable(void){
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
    PORT_TIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/telosb/spi.c
+++ b/bsp/boards/telosb/spi.c
@@ -36,7 +36,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
    memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -189,7 +189,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE   
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/telosb/uart.c
+++ b/bsp/boards/telosb/uart.c
@@ -23,7 +23,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    P3SEL                    |=  0xc0;            // P3.6,7 = UART1TX/RX
    
    UCTL1                     =  SWRST;           // hold UART1 module in reset
@@ -81,13 +81,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.txCb();
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.rxCb();
    return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/wsn430v13b/board.c
+++ b/bsp/boards/wsn430v13b/board.c
@@ -28,7 +28,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    // disable watchdog timer
    WDTCTL     =  WDTPW + WDTHOLD;
    
@@ -53,11 +53,11 @@ void board_init() {
    __bis_SR_register(GIE);
 }
 
-void board_sleep() {
+void board_sleep(void) {
    __bis_SR_register(GIE+LPM0_bits);             // sleep, but leave ACLK on
 }
 
-void board_reset() {
+void board_reset(void) {
    WDTCTL = (WDTPW+0x1200) + WDTHOLD; // writing a wrong watchdog password to causes handler to reset
 }
 

--- a/bsp/boards/wsn430v13b/debugpins.c
+++ b/bsp/boards/wsn430v13b/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {
+void debugpins_init(void) {
    P6DIR |=  0x40;      // frame [P6.6]
    P6DIR |=  0x80;      // slot  [P6.7]
    P2DIR |=  0x08;      // fsm   [P2.3]
@@ -25,68 +25,68 @@ void debugpins_init() {
 }
 
 // P6.6
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    P6OUT ^=  0x40;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
    P6OUT &= ~0x40;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    P6OUT |=  0x40;
 }
 
 // P6.7
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
    P6OUT ^=  0x80;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
    P6OUT &= ~0x80;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
    P6OUT |=  0x80;
 }
 
 // P2.3
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
    P2OUT ^=  0x08;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
    P2OUT &= ~0x08;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
    P2OUT |=  0x08;
 }
 
 // P2.6
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
    P2OUT ^=  0x40;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
    P2OUT &= ~0x40;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
    P2OUT |=  0x40;
 }
 
 // P6.0
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
    P6OUT ^=  0x01;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
    P6OUT &= ~0x01;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
    P6OUT |=  0x01;
 }
 
 // P6.1
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
    P6OUT ^=  0x02;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
    P6OUT &= ~0x02;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
    P6OUT |=  0x02;
 }
 

--- a/bsp/boards/wsn430v13b/eui64.c
+++ b/bsp/boards/wsn430v13b/eui64.c
@@ -98,7 +98,7 @@ void eui64_get(uint8_t* addressToWrite) {    // >= 6000us
 
 // admin
 
-uint8_t ow_reset() {              // >= 960us 
+uint8_t ow_reset(void) {              // >= 960us 
    int present;
    owpin_output_low();
    delay_us(OW_DLY_H);            // t_RSTL
@@ -118,7 +118,7 @@ void ow_write_byte(uint8_t byte) {// >= 560us
    }
 }
 
-uint8_t ow_read_byte() {          // >= 560us
+uint8_t ow_read_byte(void) {          // >= 560us
    uint8_t byte = 0;
    uint8_t bit;
    for( bit=0x01; bit!=0; bit<<=1 ) {
@@ -139,7 +139,7 @@ void ow_write_bit(int is_one) {   // >= 70us
    }
 }
 
-uint8_t ow_read_bit() {           // >= 70us
+uint8_t ow_read_bit(void) {           // >= 70us
    int bit;
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_RL
@@ -150,14 +150,14 @@ uint8_t ow_read_bit() {           // >= 70us
    return bit;
 }
 
-void ow_write_bit_one() {         // >= 70us
+void ow_write_bit_one(void) {         // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_W1L
    owpin_output_high();
    delay_us(OW_DLY_B);            // t_SLOT - t_W1L
 }
 
-void ow_write_bit_zero() {        // >= 70us
+void ow_write_bit_zero(void) {        // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_C);            // t_W0L
    owpin_output_high();
@@ -196,23 +196,23 @@ void delay_us(uint16_t delay) {
 
 //===== pin
 
-void    owpin_init() {
+void    owpin_init(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
    P2OUT &= ~PIN_1WIRE;           // pull low
 }
 
-void    owpin_output_low() {
+void    owpin_output_low(void) {
    P2DIR |=  PIN_1WIRE;           // set as output
 }
 
-void    owpin_output_high() {
+void    owpin_output_high(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-void    owpin_prepare_read() {
+void    owpin_prepare_read(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-uint8_t owpin_read() {
+uint8_t owpin_read(void) {
    return (P2IN & PIN_1WIRE);
 }

--- a/bsp/boards/wsn430v13b/leds.c
+++ b/bsp/boards/wsn430v13b/leds.c
@@ -15,25 +15,25 @@
 
 //=========================== public ==========================================
 
-void    leds_init() {
+void    leds_init(void) {
    P5DIR     |=  0x70;                           // P5DIR = 0bx111xxxx for LEDs
    P5OUT     |=  0x70;                           // P2OUT = 0bx111xxxx, all LEDs off
 }
 
 // red = LED1 = P5.4
-void    leds_error_on() {
+void    leds_error_on(void) {
    P5OUT     &= ~0x10;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    P5OUT     |=  0x10;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    P5OUT     ^=  0x10;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
    return (uint8_t)(P5OUT & 0x10)>>4;
 }
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    // turn all LEDs off
@@ -47,57 +47,57 @@ void leds_error_blink() {
 }
 
 // green = LED2 = P5.5
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    P5OUT     &= ~0x20;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    P5OUT     |=  0x20;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    P5OUT     ^=  0x20;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
    return (uint8_t)(P5OUT & 0x20)>>5;
 }
 
 // blue = LED3 = P5.6
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    P5OUT     &= ~0x40;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    P5OUT     |=  0x40;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    P5OUT     ^=  0x40;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    return (uint8_t)(P5OUT & 0x40)>>6;
 }
 
-void    leds_debug_on() {
+void    leds_debug_on(void) {
 }
 
-void    leds_debug_off() {
+void    leds_debug_off(void) {
 }
 
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
 }
 
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    return 0;
 }
 
-void    leds_all_on() {
+void    leds_all_on(void) {
    P5OUT     &= ~0x70;
 }
-void    leds_all_off() {
+void    leds_all_off(void) {
    P5OUT     |=  0x70;
 }
-void    leds_all_toggle() {
+void    leds_all_toggle(void) {
    P5OUT     ^=  0x70;
 }
 
-void    leds_circular_shift() {
+void    leds_circular_shift(void) {
    uint8_t leds_on;
    // get LED state
    leds_on  = (~P5OUT & 0x70) >> 4;
@@ -117,7 +117,7 @@ void    leds_circular_shift() {
    P5OUT &= ~( leds_on & 0x70);                  // switch off the leds marked '0' in leds_on
 }
 
-void    leds_increment() {
+void    leds_increment(void) {
    uint8_t leds_on;
    // get LED state
    leds_on  = (~P5OUT & 0x70) >> 4;

--- a/bsp/boards/wsn430v13b/sctimer.c
+++ b/bsp/boards/wsn430v13b/sctimer.c
@@ -110,7 +110,7 @@ void sctimer_disable(void){
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
    PORT_TIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/wsn430v13b/spi.c
+++ b/bsp/boards/wsn430v13b/spi.c
@@ -36,7 +36,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
    memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -192,7 +192,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE   
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/wsn430v13b/uart.c
+++ b/bsp/boards/wsn430v13b/uart.c
@@ -23,7 +23,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    
    P3SEL                    |=  0xc0;            // P3.6,7 = UART1TX/RX
    
@@ -83,13 +83,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.txCb();
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.rxCb();
    return DO_NOT_KICK_SCHEDULER;

--- a/bsp/boards/wsn430v14/eui64.c
+++ b/bsp/boards/wsn430v14/eui64.c
@@ -122,7 +122,7 @@ void eui64_get(uint8_t* addressToWrite) {    // >= 6000us
 
 // admin
 
-uint8_t ow_reset() {              // >= 960us 
+uint8_t ow_reset(void) {              // >= 960us 
    int present;
    owpin_output_low();
    delay_us(OW_DLY_H);            // t_RSTL
@@ -142,7 +142,7 @@ void ow_write_byte(uint8_t byte) {// >= 560us
    }
 }
 
-uint8_t ow_read_byte() {          // >= 560us
+uint8_t ow_read_byte(void) {          // >= 560us
    uint8_t byte = 0;
    uint8_t bit;
    for( bit=0x01; bit!=0; bit<<=1 ) {
@@ -163,7 +163,7 @@ void ow_write_bit(int is_one) {   // >= 70us
    }
 }
 
-uint8_t ow_read_bit() {           // >= 70us
+uint8_t ow_read_bit(void) {           // >= 70us
    int bit;
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_RL
@@ -174,14 +174,14 @@ uint8_t ow_read_bit() {           // >= 70us
    return bit;
 }
 
-void ow_write_bit_one() {         // >= 70us
+void ow_write_bit_one(void) {         // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_W1L
    owpin_output_high();
    delay_us(OW_DLY_B);            // t_SLOT - t_W1L
 }
 
-void ow_write_bit_zero() {        // >= 70us
+void ow_write_bit_zero(void) {        // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_C);            // t_W0L
    owpin_output_high();
@@ -220,23 +220,23 @@ void delay_us(uint16_t delay) {
 
 //===== pin
 
-void    owpin_init() {
+void    owpin_init(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
    P2OUT &= ~PIN_1WIRE;           // pull low
 }
 
-void    owpin_output_low() {
+void    owpin_output_low(void) {
    P2DIR |=  PIN_1WIRE;           // set as output
 }
 
-void    owpin_output_high() {
+void    owpin_output_high(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-void    owpin_prepare_read() {
+void    owpin_prepare_read(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-uint8_t owpin_read() {
+uint8_t owpin_read(void) {
    return (P2IN & PIN_1WIRE);
 }

--- a/bsp/boards/wsn430v14/sctimer.c
+++ b/bsp/boards/wsn430v14/sctimer.c
@@ -102,7 +102,7 @@ void sctimer_disable(void){
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
    PORT_TIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/z1/board.c
+++ b/bsp/boards/z1/board.c
@@ -32,7 +32,7 @@ int main(void) {
 
 //=========================== public ==========================================
 
-void board_init() {
+void board_init(void) {
    
    // disable watchdog timer
    WDTCTL  = WDTPW + WDTHOLD;
@@ -70,11 +70,11 @@ void board_init() {
    __bis_SR_register(GIE);
 }
 
-void board_sleep() {
+void board_sleep(void) {
    __bis_SR_register(GIE+LPM3_bits);             // sleep, but leave ACLK on
 }
 
-void board_reset() {
+void board_reset(void) {
    WDTCTL = (WDTPW+0x1200) + WDTHOLD; // writing a wrong watchdog password to causes handler to reset
 }
 

--- a/bsp/boards/z1/debugpins.c
+++ b/bsp/boards/z1/debugpins.c
@@ -15,7 +15,7 @@
 
 //=========================== public ==========================================
 
-void debugpins_init() {  //JP1C all in a line
+void debugpins_init(void) {  //JP1C all in a line
    P1DIR |=  0x40;      // frame [P1.0]
    P6DIR |=  0x80;      // slot  [P1.6]
    P2DIR |=  0x08;      // fsm   [P1.7]
@@ -25,68 +25,68 @@ void debugpins_init() {  //JP1C all in a line
 }
 
 // P1.0
-void debugpins_frame_toggle() {
+void debugpins_frame_toggle(void) {
    P1OUT ^=  0x01;
 }
-void debugpins_frame_clr() {
+void debugpins_frame_clr(void) {
    P1OUT &= ~0x01;
 }
-void debugpins_frame_set() {
+void debugpins_frame_set(void) {
    P1OUT |=  0x01;
 }
 
 // P1.6
-void debugpins_slot_toggle() {
+void debugpins_slot_toggle(void) {
    P1OUT ^=  0x40;
 }
-void debugpins_slot_clr() {
+void debugpins_slot_clr(void) {
    P1OUT &= ~0x40;
 }
-void debugpins_slot_set() {
+void debugpins_slot_set(void) {
    P1OUT |=  0x40;
 }
 
 // P1.7
-void debugpins_fsm_toggle() {
+void debugpins_fsm_toggle(void) {
    P1OUT ^=  0x80;
 }
-void debugpins_fsm_clr() {
+void debugpins_fsm_clr(void) {
    P1OUT &= ~0x80;
 }
-void debugpins_fsm_set() {
+void debugpins_fsm_set(void) {
    P1OUT |=  0x80;
 }
 
 // P2.1
-void debugpins_task_toggle() {
+void debugpins_task_toggle(void) {
    P2OUT ^=  0x02;
 }
-void debugpins_task_clr() {
+void debugpins_task_clr(void) {
    P2OUT &= ~0x02;
 }
-void debugpins_task_set() {
+void debugpins_task_set(void) {
    P2OUT |=  0x02;
 }
 
 // P2.3
-void debugpins_isr_toggle() {
+void debugpins_isr_toggle(void) {
    P2OUT ^=  0x08;
 }
-void debugpins_isr_clr() {
+void debugpins_isr_clr(void) {
    P2OUT &= ~0x08;
 }
-void debugpins_isr_set() {
+void debugpins_isr_set(void) {
    P2OUT |=  0x08;
 }
 
 // P4.3
-void debugpins_radio_toggle() {
+void debugpins_radio_toggle(void) {
    P4OUT ^=  0x08;
 }
-void debugpins_radio_clr() {
+void debugpins_radio_clr(void) {
    P4OUT &= ~0x08;
 }
-void debugpins_radio_set() {
+void debugpins_radio_set(void) {
    P4OUT |=  0x08;
 }
 

--- a/bsp/boards/z1/eui64.c
+++ b/bsp/boards/z1/eui64.c
@@ -100,7 +100,7 @@ void eui64_get(uint8_t* addressToWrite) {    // >= 6000us
 
 // admin
 
-uint8_t ow_reset() {              // >= 960us 
+uint8_t ow_reset(void) {              // >= 960us 
    int present;
    owpin_output_low();
    delay_us(OW_DLY_H);            // t_RSTL
@@ -120,7 +120,7 @@ void ow_write_byte(uint8_t byte) {// >= 560us
    }
 }
 
-uint8_t ow_read_byte() {          // >= 560us
+uint8_t ow_read_byte(void) {          // >= 560us
    uint8_t byte = 0;
    uint8_t bit;
    for( bit=0x01; bit!=0; bit<<=1 ) {
@@ -141,7 +141,7 @@ void ow_write_bit(int is_one) {   // >= 70us
    }
 }
 
-uint8_t ow_read_bit() {           // >= 70us
+uint8_t ow_read_bit(void) {           // >= 70us
    int bit;
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_RL
@@ -152,14 +152,14 @@ uint8_t ow_read_bit() {           // >= 70us
    return bit;
 }
 
-void ow_write_bit_one() {         // >= 70us
+void ow_write_bit_one(void) {         // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_A);            // t_W1L
    owpin_output_high();
    delay_us(OW_DLY_B);            // t_SLOT - t_W1L
 }
 
-void ow_write_bit_zero() {        // >= 70us
+void ow_write_bit_zero(void) {        // >= 70us
    owpin_output_low();
    delay_us(OW_DLY_C);            // t_W0L
    owpin_output_high();
@@ -198,23 +198,23 @@ void delay_us(uint16_t delay) {
 
 //===== pin
 
-void    owpin_init() {
+void    owpin_init(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
    P2OUT &= ~PIN_1WIRE;           // pull low
 }
 
-void    owpin_output_low() {
+void    owpin_output_low(void) {
    P2DIR |=  PIN_1WIRE;           // set as output
 }
 
-void    owpin_output_high() {
+void    owpin_output_high(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-void    owpin_prepare_read() {
+void    owpin_prepare_read(void) {
    P2DIR &= ~PIN_1WIRE;           // set as input
 }
 
-uint8_t owpin_read() {
+uint8_t owpin_read(void) {
    return (P2IN & PIN_1WIRE);
 }

--- a/bsp/boards/z1/i2c.c
+++ b/bsp/boards/z1/i2c.c
@@ -57,7 +57,7 @@ uint8_t  i2c_busy(uint8_t bus_num);
 
 //#define bus_num 1
 
-void i2c_init() {
+void i2c_init(void) {
    i2c_control.ctl0[0]       = &UCB0CTL0;
    i2c_control.ctl0[1]       = &UCB1CTL0;
    i2c_control.ctl1[0]       = &UCB0CTL1;

--- a/bsp/boards/z1/leds.c
+++ b/bsp/boards/z1/leds.c
@@ -16,78 +16,78 @@
 
 //=========================== public ==========================================
 
-void leds_init() {
+void leds_init(void) {
    P5DIR      |=  0x70;                          // P5DIR = 0bx111xxxx for LEDs
    P5OUT      |=  0x70;                          // P5OUT = 0bxxxx0000, all LEDs off
 }
 
 // red
-void    leds_error_on() {
+void    leds_error_on(void) {
    P5OUT     &=  ~0x10;
 }
-void    leds_error_off() {
+void    leds_error_off(void) {
    P5OUT     |=  0x10;
 }
-void    leds_error_toggle() {
+void    leds_error_toggle(void) {
    P5OUT     ^=  0x10;
 }
-uint8_t leds_error_isOn() {
+uint8_t leds_error_isOn(void) {
    return (uint8_t)(P5OUT & 0x10)>>5;
 }
 
 // orange
-void    leds_radio_on() {
+void    leds_radio_on(void) {
    P5OUT     &= ~0x20;
 }
-void    leds_radio_off() {
+void    leds_radio_off(void) {
    P5OUT     |= 0x20;
 }
-void    leds_radio_toggle() {
+void    leds_radio_toggle(void) {
    P5OUT     ^=  0x20;
 }
-uint8_t leds_radio_isOn() {
+uint8_t leds_radio_isOn(void) {
    return (P5OUT & 0x20)>>6;
 }
 
 // green
-void    leds_sync_on() {
+void    leds_sync_on(void) {
    P5OUT     &= ~0x40;
 }
-void    leds_sync_off() {
+void    leds_sync_off(void) {
    P5OUT     |= 0x40;
 }
-void    leds_sync_toggle() {
+void    leds_sync_toggle(void) {
    P5OUT     ^=  0x40;
 }
-uint8_t leds_sync_isOn() {
+uint8_t leds_sync_isOn(void) {
    return (P5OUT & 0x40)>>7;
 }
 
 // 3 leds only
-void    leds_debug_on() {
+void    leds_debug_on(void) {
   
 }
-void    leds_debug_off() {
+void    leds_debug_off(void) {
   
 }
-void    leds_debug_toggle() {
+void    leds_debug_toggle(void) {
   
 }
-uint8_t leds_debug_isOn() {
+uint8_t leds_debug_isOn(void) {
    return 0;
 }
 
-void leds_all_on() {
+void leds_all_on(void) {
    P5OUT     &= ~0x70;
 }
-void leds_all_off() {
+void leds_all_off(void) {
    P5OUT     |=  0x70;
 }
-void leds_all_toggle() {
+void leds_all_toggle(void) {
    P5OUT     ^=  0x70;
 }
 
-void leds_error_blink() {
+void leds_error_blink(void) {
    uint8_t i;
    volatile uint16_t delay;
    // turn all LEDs off
@@ -101,7 +101,7 @@ void leds_error_blink() {
    }
 }
 
-void leds_circular_shift() {
+void leds_circular_shift(void) {
    uint8_t temp_leds;
    if ((P5OUT & 0x70)==0) {                      // if no LEDs on, switch on first one
       P5OUT |= 0x10;
@@ -116,7 +116,7 @@ void leds_circular_shift() {
    P5OUT &= ~(~temp_leds & 0x70);                // switch off the leds marked '0' in temp_leds
 }
 
-void leds_increment() {
+void leds_increment(void) {
    uint8_t led_counter;
    led_counter = ((P5OUT & 0x70)+1);
    P5OUT &= ~0x70; //all LEDs off

--- a/bsp/boards/z1/sctimer.c
+++ b/bsp/boards/z1/sctimer.c
@@ -110,7 +110,7 @@ void sctimer_disable(void){
 /**
 \brief TimerB CCR1-6 interrupt service routine
 */
-kick_scheduler_t sctimer_isr() {
+kick_scheduler_t sctimer_isr(void) {
    PORT_TIMER_WIDTH tbiv_local;
    
    // reading TBIV returns the value of the highest pending interrupt flag

--- a/bsp/boards/z1/spi.c
+++ b/bsp/boards/z1/spi.c
@@ -38,7 +38,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
    // clear variables
    memset(&spi_vars,0,sizeof(spi_vars_t));
    
@@ -164,7 +164,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE
    // save the byte just received in the RX buffer
    switch (spi_vars.returnType) {

--- a/bsp/boards/z1/uart.c
+++ b/bsp/boards/z1/uart.c
@@ -25,7 +25,7 @@ uart_vars_t uart_vars;
 
 //=========================== public ==========================================
 
-void uart_init() {
+void uart_init(void) {
    // reset local variables
    memset(&uart_vars,0,sizeof(uart_vars_t));
    
@@ -73,13 +73,13 @@ uint8_t uart_readByte(){
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t uart_tx_isr() {
+kick_scheduler_t uart_tx_isr(void) {
    uart_clearTxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.txCb();
    return DO_NOT_KICK_SCHEDULER;
 }
 
-kick_scheduler_t uart_rx_isr() {
+kick_scheduler_t uart_rx_isr(void) {
    uart_clearRxInterrupts(); // TODO: do not clear, but disable when done
    uart_vars.rxCb();
    return DO_NOT_KICK_SCHEDULER;

--- a/bsp/chips/at86rf215/radio.c
+++ b/bsp/chips/at86rf215/radio.c
@@ -234,7 +234,7 @@ void radio_read_isr(uint8_t* rf09_isr){
 //=========================== callbacks =======================================
 
 //=========================== interrupt handlers ==============================
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
     PORT_TIMER_WIDTH capturedTime;
     // capture the time
     capturedTime = radiotimer_getCapturedTime();

--- a/bsp/chips/at86rf215/spi.c
+++ b/bsp/chips/at86rf215/spi.c
@@ -37,7 +37,7 @@ spi_vars_t spi_vars;
 
 //=========================== public ==========================================
 
-void spi_init() {
+void spi_init(void) {
     // clear variables
     memset(&spi_vars,0,sizeof(spi_vars_t));  
    
@@ -179,7 +179,7 @@ void spi_txrx(uint8_t*     bufTx,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t spi_isr() {
+kick_scheduler_t spi_isr(void) {
 #ifdef SPI_IN_INTERRUPT_MODE   
     // save the byte just received in the RX buffer
     switch (spi_vars.returnType) {

--- a/bsp/chips/at86rf231/radio.c
+++ b/bsp/chips/at86rf231/radio.c
@@ -40,7 +40,7 @@ uint8_t radio_spiReadRadioInfo(void);
 
 //===== admin
 
-void radio_init() {
+void radio_init(void) {
 
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
@@ -80,7 +80,7 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
    PORT_PIN_RADIO_RESET_LOW();
 }
 
@@ -97,12 +97,12 @@ void radio_setFrequency(uint8_t frequency) {
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    PORT_PIN_RADIO_RESET_LOW();
    PORT_PIN_RADIO_RESET_HIGH();
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
    radio_spiReadReg(RG_TRX_STATUS);
@@ -132,7 +132,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
    
@@ -148,7 +148,7 @@ void radio_txEnable() {
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    PORT_TIMER_WIDTH val;
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
@@ -173,7 +173,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
    
@@ -191,7 +191,7 @@ void radio_rxEnable() {
    radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    // nothing to do
 }
 
@@ -376,7 +376,7 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
    PORT_TIMER_WIDTH capturedTime;
    uint8_t  irq_status;
 

--- a/bsp/chips/at86rf233/radio.c
+++ b/bsp/chips/at86rf233/radio.c
@@ -68,7 +68,7 @@ uint8_t radio_spiReadRadioInfo();
 //===== admin
 extern uint8_t trx_reg_read(uint8_t addr);
 
-void radio_init() {
+void radio_init(void) {
    // clear variables
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
@@ -113,7 +113,7 @@ void radio_setEndFrameCb(radiotimer_capture_cbt cb) {
 
 //===== reset
 
-void radio_reset() {
+void radio_reset(void) {
    PORT_PIN_RADIO_RESET_LOW();
 }
 
@@ -123,7 +123,7 @@ void radio_startTimer(PORT_TIMER_WIDTH period) {
    radiotimer_start(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerValue() {
+PORT_TIMER_WIDTH radio_getTimerValue(void) {
    return radiotimer_getValue();
 }
 
@@ -131,7 +131,7 @@ void radio_setTimerPeriod(PORT_TIMER_WIDTH period) {
    radiotimer_setPeriod(period);
 }
 
-PORT_TIMER_WIDTH radio_getTimerPeriod() {
+PORT_TIMER_WIDTH radio_getTimerPeriod(void) {
    return radiotimer_getPeriod();
 }
 
@@ -148,11 +148,11 @@ void radio_setFrequency(uint8_t frequency) {
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
    PORT_PIN_RADIO_RESET_LOW();
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
    radio_spiReadReg(RG_TRX_STATUS);
@@ -182,7 +182,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
    
@@ -198,7 +198,7 @@ void radio_txEnable() {
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
-void radio_txNow() {
+void radio_txNow(void) {
    PORT_TIMER_WIDTH val;
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
@@ -223,7 +223,7 @@ void radio_txNow() {
 
 //===== RX
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
    
@@ -241,7 +241,7 @@ void radio_rxEnable() {
    radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
    // nothing to do
 }
 
@@ -426,7 +426,7 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
 
 //=========================== interrupt handlers ==============================
 
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
    PORT_TIMER_WIDTH capturedTime;
    uint8_t  irq_status;
 

--- a/bsp/chips/cc1101/radio.c
+++ b/bsp/chips/cc1101/radio.c
@@ -42,7 +42,7 @@ void delay(uint16_t usec) {
 
 //==== admin
 
-void radio_init() {
+void radio_init(void) {
 
   // clear variables
   memset(&radio_vars, 0, sizeof(radio_vars_t));
@@ -91,7 +91,7 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 
 //==== reset
 
-void radio_reset() {
+void radio_reset(void) {
   cc1101_IOCFG0_reg_t   cc1101_IOCFG0_reg;
   cc1101_PKTCTRL0_reg_t cc1101_PKTCTRL0_reg;
   cc1101_PKTLEN_reg_t   cc1101_PKTLEN_reg;
@@ -194,11 +194,11 @@ void radio_setFrequency(uint8_t frequency) {
   
 }
 
-void radio_rfOn() {
+void radio_rfOn(void) {
   // crystal oscillator already on
 }
 
-void radio_rfOff() {
+void radio_rfOff(void) {
   // change state
   radio_vars.state = RADIOSTATE_TURNING_OFF;
 
@@ -226,7 +226,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
-void radio_txEnable() {
+void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
    
@@ -239,7 +239,7 @@ void radio_txEnable() {
 }
 
 
-void radio_txNow() {
+void radio_txNow(void) {
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
    
@@ -249,7 +249,7 @@ void radio_txNow() {
 //==== RX
 
 
-void radio_rxEnable() {
+void radio_rxEnable(void) {
 
    // change state
   radio_vars.state = RADIOSTATE_ENABLING_RX;
@@ -273,7 +273,7 @@ void radio_rxEnable() {
   radio_vars.state = RADIOSTATE_LISTENING;
 }
 
-void radio_rxNow() {
+void radio_rxNow(void) {
   // nothing to do, the radio is already listening.
 }
 

--- a/bsp/chips/cc1200/radio.c
+++ b/bsp/chips/cc1200/radio.c
@@ -253,7 +253,7 @@ void radio_getReceivedFrame(
 //=========================== callbacks =======================================
 
 //=========================== interrupt handlers ==============================
-kick_scheduler_t radio_isr() {
+kick_scheduler_t radio_isr(void) {
     PORT_TIMER_WIDTH capturedTime;
     //uint8_t  irq_status;
     // capture the time

--- a/drivers/common/openserial.c
+++ b/drivers/common/openserial.c
@@ -64,7 +64,7 @@ void sniffer_setListeningChannel(uint8_t channel);
 
 //===== admin
 
-void openserial_init() {
+void openserial_init(void) {
     uint16_t crc;
     
     // reset variable
@@ -247,7 +247,7 @@ owerror_t openserial_printSniffedPacket(uint8_t* buffer, uint8_t length, uint8_t
 
 //===== retrieving inputBuffer
 
-uint8_t openserial_getInputBufferFilllevel() {
+uint8_t openserial_getInputBufferFilllevel(void) {
     uint8_t inputBufFill;
     INTERRUPT_DECLARATION();
     
@@ -285,7 +285,7 @@ uint8_t openserial_getInputBuffer(uint8_t* bufferToWrite, uint8_t maxNumBytes) {
 
 //===== scheduling
 
-void openserial_startInput() {
+void openserial_startInput(void) {
     INTERRUPT_DECLARATION();
     
     if (openserial_vars.inputBufFill>0) {
@@ -320,7 +320,7 @@ void openserial_startInput() {
     ENABLE_INTERRUPTS();
 }
 
-void openserial_startOutput() {
+void openserial_startOutput(void) {
     uint8_t debugPrintCounter;
     INTERRUPT_DECLARATION();
     
@@ -410,7 +410,7 @@ void openserial_startOutput() {
     ENABLE_INTERRUPTS();
 }
 
-void openserial_stop() {
+void openserial_stop(void) {
     uint8_t inputBufFill;
     uint8_t cmdByte;
     bool    busyReceiving;
@@ -485,7 +485,7 @@ status information about several modules in the OpenWSN stack.
 
 \returns TRUE if this function printed something, FALSE otherwise.
 */
-bool debugPrint_outBufferIndexes() {
+bool debugPrint_outBufferIndexes(void) {
     uint16_t temp_buffer[2];
     INTERRUPT_DECLARATION();
     
@@ -797,7 +797,7 @@ void openserial_board_reset_cb(opentimers_id_t id) {
 /**
 \brief Start an HDLC frame in the output buffer.
 */
-port_INLINE void outputHdlcOpen() {
+port_INLINE void outputHdlcOpen(void) {
     // initialize the value of the CRC
     openserial_vars.outputCrc                                        = HDLC_CRCINIT;
 
@@ -822,7 +822,7 @@ port_INLINE void outputHdlcWrite(uint8_t b) {
 /**
 \brief Finalize the outgoing HDLC frame.
 */
-port_INLINE void outputHdlcClose() {
+port_INLINE void outputHdlcClose(void) {
     uint16_t   finalCrc;
 
     // finalize the calculation of the CRC
@@ -841,7 +841,7 @@ port_INLINE void outputHdlcClose() {
 /**
 \brief Start an HDLC frame in the input buffer.
 */
-port_INLINE void inputHdlcOpen() {
+port_INLINE void inputHdlcOpen(void) {
     // reset the input buffer index
     openserial_vars.inputBufFill                                     = 0;
 
@@ -871,7 +871,7 @@ port_INLINE void inputHdlcWrite(uint8_t b) {
 /**
 \brief Finalize the incoming HDLC frame.
 */
-port_INLINE void inputHdlcClose() {
+port_INLINE void inputHdlcClose(void) {
     
     // verify the validity of the frame
     if (openserial_vars.inputCrc==HDLC_CRCGOOD) {
@@ -890,7 +890,7 @@ port_INLINE void inputHdlcClose() {
 //=========================== interrupt handlers ==============================
 
 // executed in ISR, called from scheduler.c
-void isr_openserial_tx() {
+void isr_openserial_tx(void) {
     switch (openserial_vars.mode) {
         case MODE_INPUT:
             openserial_vars.reqFrameIdx++;
@@ -913,7 +913,7 @@ void isr_openserial_tx() {
 }
 
 // executed in ISR, called from scheduler.c
-void isr_openserial_rx() {
+void isr_openserial_rx(void) {
     uint8_t rxbyte;
     uint8_t inputBufFill;
 

--- a/drivers/gina/ADC_Channel.c
+++ b/drivers/gina/ADC_Channel.c
@@ -8,7 +8,7 @@ bool ADC_configured = FALSE;
 
 //===================================== public ================================
 
-void ADC_init() {
+void ADC_init(void) {
   volatile int i;
   
   // enable accelerometer and filter
@@ -38,10 +38,10 @@ void ADC_init() {
   ADC_configured = TRUE;
 }
 
-void ADC_disable() {
+void ADC_disable(void) {
   P6OUT   &=  ~0x08;   //Turn off P6.3 to disable accelerometer and filter
 }
-void ADC_get_config() {
+void ADC_get_config(void) {
   if (ADC_configured==TRUE) {
   }
 }

--- a/drivers/gina/button.c
+++ b/drivers/gina/button.c
@@ -6,7 +6,7 @@
 
 //=========================== public ==========================================
 
-void button_init() {
+void button_init(void) {
    // button connected to P2.7, i.e. configuration 0x80 in P2XX register
    P2DIR  &= ~0x80;                              // input direction
    P2REN  |=  0x80;                              // enable internal resistor

--- a/drivers/gina/gyro.c
+++ b/drivers/gina/gyro.c
@@ -19,7 +19,7 @@ gyro_vars_t gyro_vars;
 
 //=========================== public ==========================================
 
-void gyro_init() {
+void gyro_init(void) {
    uint8_t reg[]={GYRO_REG_SMPLRT_DIV_ADDR,GYRO_REG_SMPLRT_DIV_SETTING};
    
    gyro_vars.configured = FALSE;
@@ -37,12 +37,12 @@ void gyro_init() {
    gyro_vars.configured = TRUE;
 }
 
-void gyro_disable() {
+void gyro_disable(void) {
    uint8_t reg[]={GYRO_REG_PWR_MGM_ADDR,GYRO_REG_PWR_MGM_SLEEP};
    i2c_write_register(1,GYRO_I2C_ADDR, sizeof(reg), reg);
 }
 
-void gyro_get_config() {
+void gyro_get_config(void) {
    if (gyro_vars.configured==TRUE) {
       i2c_read_registers(1,GYRO_I2C_ADDR, GYRO_REG_WHO_AM_I_ADDR   ,1,&gyro_vars.reg_WHO_AM_I);
       i2c_read_registers(1,GYRO_I2C_ADDR, GYRO_REG_SMPLRT_DIV_ADDR ,1,&gyro_vars.reg_SMPLRT_DIV);

--- a/drivers/gina/heli.c
+++ b/drivers/gina/heli.c
@@ -7,17 +7,17 @@
 
 //=========================== public ==========================================
 
-void heli_init() {
+void heli_init(void) {
    // set pins P1.2,3 as output
    P1OUT   &= ~0x0C;
    P1DIR   |=  0x0C;
 }
 
-void heli_on() {
+void heli_on(void) {
    P1OUT   |=  0x0C;
 }
 
-void heli_off() {
+void heli_off(void) {
    P1OUT   &= ~0x0C;
 }
 

--- a/drivers/gina/large_range_accel.c
+++ b/drivers/gina/large_range_accel.c
@@ -15,7 +15,7 @@ large_range_accel_vars_t large_range_accel_vars;
 
 //=========================== public ==========================================
 
-void large_range_accel_init() {
+void large_range_accel_init(void) {
    uint8_t reg[]={LARGE_RANGE_ACCEL_REG_CTRL_REGC_ADDR,LARGE_RANGE_ACCEL_REG_CTRL_REGC_SETTING};
    large_range_accel_vars.configured = FALSE;
    P5OUT |=  0x10;                               // set P5.4 as output
@@ -27,12 +27,12 @@ void large_range_accel_init() {
    large_range_accel_vars.configured = TRUE;
 }
 
-void large_range_accel_disable() {
+void large_range_accel_disable(void) {
    uint8_t reg[]={LARGE_RANGE_ACCEL_REG_CTRL_REGB_ADDR,LARGE_RANGE_ACCEL_REG_CTRL_REGB_SLEEP};
    i2c_write_register(1,LARGE_RANGE_ACCEL_I2C_ADDR, sizeof(reg), reg);
 }
 
-void large_range_accel_get_config() {
+void large_range_accel_get_config(void) {
    if (large_range_accel_vars.configured==TRUE) {
       i2c_read_registers(1,LARGE_RANGE_ACCEL_I2C_ADDR,
             LARGE_RANGE_ACCEL_REG_CTRL_REGC_ADDR,

--- a/drivers/gina/magnetometer.c
+++ b/drivers/gina/magnetometer.c
@@ -20,7 +20,7 @@ magnetometer_vars_t magnetometer_vars;
 
 //=========================== public ==========================================
 
-void magnetometer_init() {
+void magnetometer_init(void) {
    uint8_t reg[]={MAGNETOMETER_REG_CONF_A_ADDR,MAGNETOMETER_REG_CONF_A_SETTING};
    
    magnetometer_vars.configured = FALSE;
@@ -33,18 +33,18 @@ void magnetometer_init() {
    magnetometer_vars.configured = TRUE;
 }
 
-void magnetometer_enable() {
+void magnetometer_enable(void) {
    i2c_write_register(1,MAGNETOMETER_I2C_ADDR,
          MAGNETOMETER_REG_MODE_ADDR,
          MAGNETOMETER_REG_MODE_WAKEUP);
 }
 
-void magnetometer_disable() {
+void magnetometer_disable(void) {
    uint8_t reg[]={MAGNETOMETER_REG_MODE_ADDR,MAGNETOMETER_REG_MODE_SLEEP};
    i2c_write_register(1,MAGNETOMETER_I2C_ADDR, sizeof(reg), reg);
 }
 
-void magnetometer_get_config() {
+void magnetometer_get_config(void) {
    if (magnetometer_vars.configured==TRUE) {
       i2c_read_registers(1,MAGNETOMETER_I2C_ADDR,MAGNETOMETER_REG_CONF_A_ADDR  ,1,&magnetometer_vars.reg_CONF_A);
       i2c_read_registers(1,MAGNETOMETER_I2C_ADDR,MAGNETOMETER_REG_CONF_B_ADDR  ,1,&magnetometer_vars.reg_CONF_B);

--- a/drivers/gina/sensitive_accel_temperature.c
+++ b/drivers/gina/sensitive_accel_temperature.c
@@ -14,7 +14,7 @@ sensitive_accel_temperature_vars_t sensitive_accel_temperature_vars;
 
 //=========================== public ==========================================
 
-void sensitive_accel_temperature_init() {
+void sensitive_accel_temperature_init(void) {
    volatile int i;
    if (sensitive_accel_temperature_vars.configured==FALSE) {
       sensitive_accel_temperature_vars.configured = FALSE;
@@ -46,10 +46,10 @@ void sensitive_accel_temperature_init() {
    }
 }
 
-void sensitive_accel_temperature_disable() {
+void sensitive_accel_temperature_disable(void) {
    P6OUT   &=  ~0x08;   //Turn off P6.3 to disable accelerometer and filter
 }
-void sensitive_accel_temperature_get_config() {
+void sensitive_accel_temperature_get_config(void) {
    if (sensitive_accel_temperature_vars.configured==TRUE) {
    }
 }

--- a/kernel/freertos/scheduler.c
+++ b/kernel/freertos/scheduler.c
@@ -19,11 +19,11 @@ scheduler_dbg_t  scheduler_dbg;
 
 //=========================== public ==========================================
 
-void scheduler_init() {   
+void scheduler_init(void) {   
    // TODO: fill in as part of FW-16.
 }
 
-void scheduler_start() {
+void scheduler_start(void) {
    // TODO: fill in as part of FW-16.
 }
 

--- a/kernel/openos/scheduler.c
+++ b/kernel/openos/scheduler.c
@@ -21,7 +21,7 @@ void consumeTask(uint8_t taskId);
 
 //=========================== public ==========================================
 
-void scheduler_init() {   
+void scheduler_init(void) {   
    
    // initialization module variables
    memset(&scheduler_vars,0,sizeof(scheduler_vars_t));
@@ -31,7 +31,7 @@ void scheduler_init() {
    SCHEDULER_ENABLE_INTERRUPT();
 }
 
-void scheduler_start() {
+void scheduler_start(void) {
    taskList_item_t* pThisTask;
    while (1) {
       while(scheduler_vars.task_list!=NULL) {

--- a/openapps/c6t/c6t.c
+++ b/openapps/c6t/c6t.c
@@ -36,7 +36,7 @@ void    c6t_sendDone(
 
 //=========================== public ==========================================
 
-void c6t_init() {
+void c6t_init(void) {
    if(idmanager_getIsDAGroot()==TRUE) return; 
    
    // prepare the resource descriptor for the /6t path

--- a/openapps/cexample/cexample.c
+++ b/openapps/cexample/cexample.c
@@ -41,7 +41,7 @@ void    cexample_sendDone(OpenQueueEntry_t* msg,
 
 //=========================== public ==========================================
 
-void cexample_init() {
+void cexample_init(void) {
    
     // prepare the resource descriptor for the /ex path
     cexample_vars.desc.path0len             = sizeof(cexample_path0)-1;
@@ -83,7 +83,7 @@ void cexample_timer_cb(opentimers_id_t id){
    scheduler_push_task(cexample_task_cb,TASKPRIO_COAP);
 }
 
-void cexample_task_cb() {
+void cexample_task_cb(void) {
    OpenQueueEntry_t*    pkt;
    owerror_t            outcome;
    uint8_t              i;

--- a/openapps/cinfo/cinfo.c
+++ b/openapps/cinfo/cinfo.c
@@ -39,7 +39,7 @@ void          cinfo_sendDone(
 /**
 \brief Initialize this module.
 */
-void cinfo_init() {
+void cinfo_init(void) {
    // do not run if DAGroot
    if(idmanager_getIsDAGroot()==TRUE) return; 
    

--- a/openapps/cinfrared/cinfrared.c
+++ b/openapps/cinfrared/cinfrared.c
@@ -37,7 +37,7 @@ void cinrared_turnOnOrOff(uint8_t turnOnOrOff);
 
 //=========================== public ==========================================
 
-void cinfrared_init() {
+void cinfrared_init(void) {
     if(idmanager_getIsDAGroot()==TRUE) return; 
 
     // prepare the resource descriptor for the /6t path

--- a/openapps/cjoin/cjoin.c
+++ b/openapps/cjoin/cjoin.c
@@ -55,7 +55,7 @@ bool        cjoin_getIsJoined(void);
 void        cjoin_setIsJoined(bool newValue);
 //=========================== public ==========================================
 
-void cjoin_init() {
+void cjoin_init(void) {
    // declare the usage of dynamic keying to L2 security module
    IEEE802154_security_setDynamicKeying();
 
@@ -81,7 +81,7 @@ void cjoin_init() {
    cjoin_schedule();
 }
 
-void cjoin_init_security_context() {
+void cjoin_init_security_context(void) {
    uint8_t senderID[9];     // needs to hold EUI-64 + 1 byte
    uint8_t recipientID[9];  // needs to hold EUI-64 + 1 byte
    uint8_t* joinKey;
@@ -103,7 +103,7 @@ void cjoin_init_security_context() {
                                 0);
 }
 
-void cjoin_schedule() {
+void cjoin_schedule(void) {
     uint16_t delay;
     
     if (cjoin_getIsJoined() == FALSE) {
@@ -157,7 +157,7 @@ void cjoin_retransmission_cb(opentimers_id_t id) {
     scheduler_push_task(cjoin_retransmission_task_cb, TASKPRIO_COAP);
 }
 
-void cjoin_retransmission_task_cb() {
+void cjoin_retransmission_task_cb(void) {
     open_addr_t* joinProxy;
 
     joinProxy = neighbors_getJoinProxy();
@@ -174,7 +174,7 @@ void cjoin_retransmission_task_cb() {
     cjoin_sendJoinRequest(joinProxy);
 }
 
-void cjoin_task_cb() {
+void cjoin_task_cb(void) {
     open_addr_t *joinProxy;
   
     // don't run if not synch
@@ -282,7 +282,7 @@ owerror_t cjoin_sendJoinRequest(open_addr_t* joinProxy) {
   return E_SUCCESS;
 }
 
-bool cjoin_getIsJoined() {   
+bool cjoin_getIsJoined(void) {   
    bool res;
    INTERRUPT_DECLARATION();
    

--- a/openapps/cleds/cleds.c
+++ b/openapps/cleds/cleds.c
@@ -31,7 +31,7 @@ void     cleds_sendDone(
 
 //=========================== public ==========================================
 
-void cleds__init() {
+void cleds__init(void) {
    
    // prepare the resource descriptor for the /l path
    cleds_vars.desc.path0len            = sizeof(cleds_path0)-1;

--- a/openapps/csensors/csensors.c
+++ b/openapps/csensors/csensors.c
@@ -71,7 +71,7 @@ void csensors_sendDone(
 /**
    \brief Initialize csensors and registers opensensors resources.
 */
-void csensors_init() {
+void csensors_init(void) {
    uint8_t i;
    uint8_t numSensors;
 
@@ -305,7 +305,7 @@ void csensors_timer_cb(opentimers_id_t id){
 /**
    \brief   Called back from scheduler, when a task must be executed.
 */
-void csensors_task_cb() {
+void csensors_task_cb(void) {
    OpenQueueEntry_t*          pkt;
    owerror_t                  outcome;
    uint8_t                    id;

--- a/openapps/cstorm/cstorm.c
+++ b/openapps/cstorm/cstorm.c
@@ -155,7 +155,7 @@ void cstorm_timer_cb(){
    scheduler_push_task(cstorm_task_cb,TASKPRIO_COAP);
 }
 
-void cstorm_task_cb() {
+void cstorm_task_cb(void) {
    OpenQueueEntry_t*    pkt;
    owerror_t            outcome;
    coap_option_iht      options[2];

--- a/openapps/cwellknown/cwellknown.c
+++ b/openapps/cwellknown/cwellknown.c
@@ -29,7 +29,7 @@ void    cwellknown_sendDone(
 
 //=========================== public ==========================================
 
-void cwellknown_init() {
+void cwellknown_init(void) {
    if(idmanager_getIsDAGroot()==TRUE) return; 
    
    // prepare the resource descriptor for the /.well-known/core path

--- a/openapps/opencoap/opencoap.c
+++ b/openapps/opencoap/opencoap.c
@@ -55,7 +55,7 @@ void opencoap_forward_message(OpenQueueEntry_t *msg,
 /**
 \brief Initialize this module.
 */
-void opencoap_init() {
+void opencoap_init(void) {
    uint16_t rand;
    uint8_t pos;
 

--- a/openapps/rrt/rrt.c
+++ b/openapps/rrt/rrt.c
@@ -46,7 +46,7 @@ void rrt_sendCoAPMsg(char actionMsg, uint8_t *ipv6mote);
 /**
 \brief Initialize this module.
 */
-void rrt_init() {
+void rrt_init(void) {
    
    // do not run if DAGroot
    if(idmanager_getIsDAGroot()==TRUE) return; 

--- a/openapps/uecho/uecho.c
+++ b/openapps/uecho/uecho.c
@@ -12,7 +12,7 @@ uecho_vars_t uecho_vars;
 
 //=========================== public ==========================================
 
-void uecho_init() {
+void uecho_init(void) {
    // clear local variables
    memset(&uecho_vars,0,sizeof(uecho_vars_t));
 
@@ -65,7 +65,7 @@ void uecho_sendDone(OpenQueueEntry_t* msg, owerror_t error) {
    openqueue_freePacketBuffer(msg);
 }
 
-bool uecho_debugPrint() {
+bool uecho_debugPrint(void) {
    return FALSE;
 }
 

--- a/openapps/uexpiration/uexpiration.c
+++ b/openapps/uexpiration/uexpiration.c
@@ -20,7 +20,7 @@ void uexpiration_task_cb(void);
 
 //=========================== public ==========================================
 
-void uexpiration_init() {
+void uexpiration_init(void) {
    // clear local variables
    memset(&uexpiration_vars,0,sizeof(uexpiration_vars_t));
 
@@ -84,7 +84,7 @@ void uexpiration_timer_cb(opentimers_id_t id){
    scheduler_push_task(uexpiration_task_cb,TASKPRIO_COAP);
 }
 
-void uexpiration_task_cb() {
+void uexpiration_task_cb(void) {
    uint16_t          temp_l4_destination_port;
    OpenQueueEntry_t* reply;
    

--- a/openapps/uexpiration_monitor/uexpiration_monitor.c
+++ b/openapps/uexpiration_monitor/uexpiration_monitor.c
@@ -14,7 +14,7 @@ umonitor_vars_t umonitor_vars;
 
 //=========================== public ==========================================
 
-void umonitor_init() {
+void umonitor_init(void) {
    // clear local variables
    memset(&umonitor_vars,0,sizeof(umonitor_vars_t));
 
@@ -73,7 +73,7 @@ void umonitor_sendDone(OpenQueueEntry_t* msg, owerror_t error) {
    openqueue_freePacketBuffer(msg);
 }
 
-bool umonitor_debugPrint() {
+bool umonitor_debugPrint(void) {
    return FALSE;
 }
 


### PR DESCRIPTION
This popped up during the OpenWSN integration into RIOT. There, warnings are treated as errors by default, which lead to tons of errors at first. What do you think about an update as proposed in this PR and how would you organize it? All in once commit, split up?

If it's not interesting to you, just close.