### PR TITLE
MAC: fix potentially uninitialized variable

### DIFF
--- a/openstack/02a-MAClow/IEEE802154.c
+++ b/openstack/02a-MAClow/IEEE802154.c
@@ -38,7 +38,7 @@ void ieee802154_prependHeader(OpenQueueEntry_t* msg,
    uint16_t     timeSyncInfo;
    uint16_t     length_elementid_type;
    bool         headerIEPresent = FALSE;
-   uint8_t      destAddrMode;
+   uint8_t      destAddrMode = -1;
    
    securityEnabled = msg->l2_securityLevel == IEEE154_ASH_SLF_TYPE_NOSEC ? 0 : 1;
 

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -1061,9 +1061,9 @@ void sixtop_six2six_notifyReceive(
     uint8_t              length,
     OpenQueueEntry_t*    pkt
 ){
-    uint8_t           returnCode;
-    uint16_t          metadata;
-    uint8_t           cellOptions;
+    uint8_t           returnCode        = -1;
+    uint16_t          metadata          = -1;
+    uint8_t           cellOptions       = -1;
     uint8_t           cellOptions_transformed;
     uint16_t          offset;
     uint16_t          length_groupid_type;


### PR DESCRIPTION
This PR sets initial values to some variables. Compiler warnings complained about potential use of uninitialized variables.