### PR TITLE
Fix "old-style function definition" warning all over the repo part 3

### DIFF
--- a/bsp/boards/agilefox/board.c
+++ b/bsp/boards/agilefox/board.c
@@ -108,6 +108,6 @@ void board_sleep(void) {
 
 
 
-void board_reset(){
+void board_reset(void) {
 }
 

--- a/bsp/boards/agilefox/leds.c
+++ b/bsp/boards/agilefox/leds.c
@@ -19,7 +19,7 @@ void Delay(void);
 
 //=========================== public ==========================================
 
-void leds_init(){
+void leds_init(void) {
    // Enable GPIOB clock 
    RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB , ENABLE);
    
@@ -31,16 +31,16 @@ void leds_init(){
 }
 
 // red
-void leds_error_on(){
+void leds_error_on(void) {
    GPIOB->ODR &= ~LED_RED_PIN;
 }
-void leds_error_off(){
+void leds_error_off(void) {
    GPIOB->ODR |= LED_RED_PIN;
 }
-void leds_error_toggle(){
+void leds_error_toggle(void) {
    GPIOB->ODR ^= LED_RED_PIN;
 }
-uint8_t leds_error_isOn(){
+uint8_t leds_error_isOn(void) {
    u8 bitstatus = 0x00;
    if ((GPIOB->ODR & LED_RED_PIN) != (u32)0) {
       bitstatus = 0x00;
@@ -53,16 +53,16 @@ void leds_error_blink(void) {
 }
 
 // green
-void leds_sync_on(){
+void leds_sync_on(void) {
    GPIOB->ODR &= ~LED_GREEN_PIN;
 }
-void leds_sync_off(){
+void leds_sync_off(void) {
    GPIOB->ODR |= LED_GREEN_PIN;
 }
-void leds_sync_toggle(){
+void leds_sync_toggle(void) {
    GPIOB->ODR ^= LED_GREEN_PIN;
 }
-uint8_t leds_sync_isOn(){
+uint8_t leds_sync_isOn(void) {
    u8 bitstatus = 0x00;
    if ((GPIOB->ODR & LED_GREEN_PIN) != (u32)0) {
       bitstatus = 0x00;
@@ -73,41 +73,41 @@ uint8_t leds_sync_isOn(){
 }
 
 // orange
-void leds_radio_on(){
+void leds_radio_on(void) {
 }
-void leds_radio_off(){
+void leds_radio_off(void) {
 }
-void leds_radio_toggle(){
+void leds_radio_toggle(void) {
 }
-uint8_t leds_radio_isOn(){
+uint8_t leds_radio_isOn(void) {
    return FALSE;
 }
 
 // yellow
-void leds_debug_on(){
+void leds_debug_on(void) {
 }
-void leds_debug_off(){
+void leds_debug_off(void) {
 }
-void leds_debug_toggle(){
+void leds_debug_toggle(void) {
 }
-uint8_t leds_debug_isOn(){
+uint8_t leds_debug_isOn(void) {
    return FALSE;
 }
 
-void leds_all_on(){
+void leds_all_on(void) {
    leds_error_on();
    leds_sync_on();
 }
-void leds_all_off(){
+void leds_all_off(void) {
    leds_error_off();
    leds_sync_off();
 }
-void leds_all_toggle(){
+void leds_all_toggle(void) {
    leds_error_toggle();
    leds_sync_toggle();
 }
 
-void leds_circular_shift(){
+void leds_circular_shift(void) {
    GPIOB->ODR ^= LED_RED_PIN;
    Delay();
    GPIOB->ODR ^= LED_RED_PIN;
@@ -118,7 +118,7 @@ void leds_circular_shift(){
    Delay();
 }
 
-void leds_increment(){
+void leds_increment(void) {
 }
 
 //=========================== private =========================================

--- a/bsp/boards/cc1200dk/uart.c
+++ b/bsp/boards/cc1200dk/uart.c
@@ -40,19 +40,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
     UCA1IE |= UCRXIE | UCTXIE ;  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
     UCA1IE &= ~(UCRXIE | UCTXIE);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
     UCA1IFG   &= ~UCRXIFG;
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
     UCA1IFG   &= ~UCTXIFG;
 }
 
@@ -60,7 +60,7 @@ void    uart_writeByte(uint8_t byteToWrite){
     UCA1TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
     return UCA1RXBUF;
 }
 

--- a/bsp/boards/derfmega/uart.c
+++ b/bsp/boards/derfmega/uart.c
@@ -50,18 +50,18 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){ 
+void    uart_enableInterrupts(void) { 
 	UCSR0B |= 0xC0;
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
 	UCSR0B &= ~0xC0;
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   UCSR0A |= 0x40;
 }
 
@@ -70,7 +70,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   UDR0 = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return UDR0;
 }
 

--- a/bsp/boards/ez430-rf2500/uart.c
+++ b/bsp/boards/ez430-rf2500/uart.c
@@ -46,19 +46,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
   UC0IE    |=  (UCA0RXIE  | UCA0TXIE);  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
   UC0IE &= ~(UCA0RXIE | UCA0TXIE);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
   UC0IFG   &= ~(UCA0RXIFG);
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   UC0IFG   &= ~(UCA0TXIFG);
 }
 
@@ -66,7 +66,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   UCA0TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return UCA0RXBUF;
 }
 

--- a/bsp/boards/gina/uart.c
+++ b/bsp/boards/gina/uart.c
@@ -45,19 +45,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
   UC1IE    |=  (UCA1RXIE  | UCA1TXIE);  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
   UC1IE &= ~(UCA1RXIE | UCA1TXIE);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
   UC1IFG   &= ~(UCA1RXIFG);
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   UC1IFG   &= ~(UCA1TXIFG);
 }
 
@@ -65,7 +65,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   UCA1TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return UCA1RXBUF;
 }
 

--- a/bsp/boards/iot-lab_A8-M3/board.c
+++ b/bsp/boards/iot-lab_A8-M3/board.c
@@ -108,7 +108,7 @@ void board_sleep(void) {
     __WFI();
 }
 
-void board_reset(){
+void board_reset(void) {
     NVIC_GenerateSystemReset();
 }
 

--- a/bsp/boards/iot-lab_M3/board.c
+++ b/bsp/boards/iot-lab_M3/board.c
@@ -93,7 +93,7 @@ void board_init(void)
     NVIC_radio();
 }
 
-void board_sleep(){
+void board_sleep(void) {
     DBGMCU_Config(DBGMCU_STOP, ENABLE);
     // Enable PWR and BKP clock
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR | RCC_APB1Periph_BKP, ENABLE);
@@ -103,7 +103,7 @@ void board_sleep(){
     __WFI();
 }
 
-void board_reset(){
+void board_reset(void) {
     NVIC_SystemReset();
 }
 

--- a/bsp/boards/iot-lab_M3/uart.c
+++ b/bsp/boards/iot-lab_M3/uart.c
@@ -86,7 +86,7 @@ void uart_disableInterrupts(void) {
     USART_ITConfig(USART1, USART_IT_RXNE, DISABLE);
 }
 
-void uart_clearRxInterrupts(){}
+void uart_clearRxInterrupts(void) {}
 
 void uart_clearTxInterrupts(void) {
     USART_ClearFlag(USART1, USART_FLAG_TC);

--- a/bsp/boards/openmote-b/board.c
+++ b/bsp/boards/openmote-b/board.c
@@ -87,7 +87,7 @@ void board_init(void) {
    cryptoengine_init();  
 }
 
-void antenna_init(){
+void antenna_init(void) {
    //use cc2538 2.4ghz radio
    GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_CC2538_24GHZ, BSP_ANTENNA_CC2538_24GHZ);
    GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_AT215_24GHZ, 0);

--- a/bsp/boards/openmote-b/uart.c
+++ b/bsp/boards/openmote-b/uart.c
@@ -94,19 +94,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     uart_vars.rxCb = rxCb;
 }
 
-void uart_enableInterrupts(){
+void uart_enableInterrupts(void) {
     UARTIntEnable(UART0_BASE, UART_INT_RX | UART_INT_TX | UART_INT_RT);
 }
 
-void uart_disableInterrupts(){
+void uart_disableInterrupts(void) {
     UARTIntDisable(UART0_BASE, UART_INT_RX | UART_INT_TX | UART_INT_RT);
 }
 
-void uart_clearRxInterrupts(){
+void uart_clearRxInterrupts(void) {
     UARTIntClear(UART0_BASE, UART_INT_RX | UART_INT_RT);
 }
 
-void uart_clearTxInterrupts(){
+void uart_clearTxInterrupts(void) {
     UARTIntClear(UART0_BASE, UART_INT_TX);
 }
 
@@ -114,7 +114,7 @@ void  uart_writeByte(uint8_t byteToWrite){
 	UARTCharPut(UART0_BASE, byteToWrite);
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
 	 int32_t i32Char;
      i32Char = UARTCharGet(UART0_BASE);
 	 return (uint8_t)(i32Char & 0xFF);

--- a/bsp/boards/openmote-cc2538/uart.c
+++ b/bsp/boards/openmote-cc2538/uart.c
@@ -94,19 +94,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     uart_vars.rxCb = rxCb;
 }
 
-void uart_enableInterrupts(){
+void uart_enableInterrupts(void) {
     UARTIntEnable(UART0_BASE, UART_INT_RX | UART_INT_TX | UART_INT_RT);
 }
 
-void uart_disableInterrupts(){
+void uart_disableInterrupts(void) {
     UARTIntDisable(UART0_BASE, UART_INT_RX | UART_INT_TX | UART_INT_RT);
 }
 
-void uart_clearRxInterrupts(){
+void uart_clearRxInterrupts(void) {
     UARTIntClear(UART0_BASE, UART_INT_RX | UART_INT_RT);
 }
 
-void uart_clearTxInterrupts(){
+void uart_clearTxInterrupts(void) {
     UARTIntClear(UART0_BASE, UART_INT_TX);
 }
 
@@ -114,7 +114,7 @@ void  uart_writeByte(uint8_t byteToWrite){
 	UARTCharPut(UART0_BASE, byteToWrite);
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
 	 int32_t i32Char;
      i32Char = UARTCharGet(UART0_BASE);
 	 return (uint8_t)(i32Char & 0xFF);

--- a/bsp/boards/openmotestm/debugpins.c
+++ b/bsp/boards/openmotestm/debugpins.c
@@ -48,7 +48,7 @@ void debugpins_init(void) {
 }
 
 // PC.5
-void debugpins_frame_toggle(){
+void debugpins_frame_toggle(void) {
     
     GPIOC->ODR ^= 0X0020;
 }

--- a/bsp/boards/openmotestm/leds.c
+++ b/bsp/boards/openmotestm/leds.c
@@ -44,7 +44,7 @@ void leds_error_toggle(void) {
    GPIOC->ODR ^= 0X0040;
 }
 
-uint8_t leds_error_isOn(){
+uint8_t leds_error_isOn(void) {
     
     u8 bitstatus = 0x00;
     if ((GPIOC->ODR & 0X0040) != (u32)0) {
@@ -55,7 +55,7 @@ uint8_t leds_error_isOn(){
     return bitstatus;
 }
 
-void leds_error_blink(){
+void leds_error_blink(void) {
     
     for(int i=0;i<16;i++) {
         leds_error_toggle();
@@ -124,17 +124,17 @@ void leds_debug_on(void) {
     GPIOC->ODR |= 0X0800;  
 }
 
-void leds_debug_off(){
+void leds_debug_off(void) {
     
     GPIOC->ODR &= ~0X0800;  
 }
 
-void leds_debug_toggle(){
+void leds_debug_toggle(void) {
     
     GPIOC->ODR ^= 0X0800;  
 }
 
-uint8_t leds_debug_isOn(){
+uint8_t leds_debug_isOn(void) {
     
     u8 bitstatus = 0x00;
     if ((GPIOC->ODR & 0X0800) != (u32)0){

--- a/bsp/boards/openmotestm/uart.c
+++ b/bsp/boards/openmotestm/uart.c
@@ -83,23 +83,23 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
      NVIC_uart();
 }
 
-void uart_enableInterrupts(){
+void uart_enableInterrupts(void) {
     
     USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
 }
 
-void uart_disableInterrupts(){
+void uart_disableInterrupts(void) {
     
     USART_ITConfig(USART1, USART_IT_TXE, DISABLE);
     USART_ITConfig(USART1, USART_IT_RXNE, DISABLE);
 }
 
-void uart_clearRxInterrupts(){
+void uart_clearRxInterrupts(void) {
     
     USART_ClearFlag(USART1,USART_FLAG_RXNE);
 }
 
-void uart_clearTxInterrupts(){
+void uart_clearTxInterrupts(void) {
     
     USART_ClearFlag(USART1,USART_FLAG_TXE);
 }

--- a/bsp/boards/scum/uart.c
+++ b/bsp/boards/scum/uart.c
@@ -41,27 +41,27 @@ void    uart_writeByte(uint8_t byteToWrite){
     uart_tx_isr();
 }
 
-void    uart_enableInterrupts(){ 
+void    uart_enableInterrupts(void) { 
     // there is no interruption register for uart on SCuM. 
     // the interruption is enabled by default, donot need to enable
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
     // there is no interruption register for uart on SCuM. 
     // the interruption is enabled by default, can't be disabled
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
     // there is no interruption clear register for uart on SCuM. 
     // not required to clear
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
     // there is no interruption clear register for uart on SCuM. 
     // not required to clear
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
     return UART_REG__RX_DATA;
 }
 

--- a/bsp/boards/silabs-ezr32wg/radiotimer.c
+++ b/bsp/boards/silabs-ezr32wg/radiotimer.c
@@ -141,7 +141,7 @@ port_INLINE uint16_t get_real_counter(void){
 
 //=========================== interrupt handlers ==============================
 
-void radiotimer_isr_private(){
+void radiotimer_isr_private(void) {
 	debugpins_isr_set();
 	radiotimer_isr();
 	debugpins_isr_clr();

--- a/bsp/boards/silabs-ezr32wg/spi.c
+++ b/bsp/boards/silabs-ezr32wg/spi.c
@@ -66,7 +66,7 @@ SPI instance initialisation
 
 */
 
-void spi_init(){
+void spi_init(void) {
 
   /* HFXO 48MHz, divided by 1 */
   CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFXO);

--- a/bsp/boards/silabs-ezr32wg/uart.c
+++ b/bsp/boards/silabs-ezr32wg/uart.c
@@ -121,23 +121,23 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
     
 }
 
-void uart_enableInterrupts(){
+void uart_enableInterrupts(void) {
 	USART_IntEnable(UART_UART, USART_IF_RXDATAV);
 	//USART_IntEnable(UART_UART, USART_IF_TXBL);
         USART_IntEnable(UART_UART, USART_IF_TXC);
 }
 
-void uart_disableInterrupts(){
+void uart_disableInterrupts(void) {
 	USART_IntDisable(UART_UART, USART_IF_RXDATAV);
 	//USART_IntDisable(UART_UART, USART_IF_TXBL);
         USART_IntDisable(UART_UART, USART_IF_TXC);
 }
 
-void uart_clearRxInterrupts(){
+void uart_clearRxInterrupts(void) {
 	USART_IntClear(UART_UART, USART_IF_RXDATAV);
 }
 
-void uart_clearTxInterrupts(){
+void uart_clearTxInterrupts(void) {
 	//USART_IntClear(UART_UART, USART_IF_TXBL);
         USART_IntClear(UART_UART, USART_IF_TXC);
 }
@@ -146,7 +146,7 @@ void  uart_writeByte(uint8_t byteToWrite){
 	USART_Tx(UART_UART, byteToWrite);
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
 	 //int32_t i32Char = 0;
 	 //i32Char = USART_Rx(UART_UART);
 	 //return (uint8_t)(i32Char & 0xFF);

--- a/bsp/boards/telosb/uart.c
+++ b/bsp/boards/telosb/uart.c
@@ -53,19 +53,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
   IE2 |=  (URXIE1 | UTXIE1);  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
   IE2 &= ~(URXIE1 | UTXIE1);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
   IFG2   &= ~URXIFG1;
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   IFG2   &= ~UTXIFG1;
 }
 
@@ -73,7 +73,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   U1TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return U1RXBUF;
 }
 

--- a/bsp/boards/wsn430v13b/uart.c
+++ b/bsp/boards/wsn430v13b/uart.c
@@ -55,19 +55,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
   IE2 |=  (URXIE1 | UTXIE1);  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
   IE2 &= ~(URXIE1 | UTXIE1);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
   IFG2   &= ~URXIFG1;
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   IFG2   &= ~UTXIFG1;
 }
 
@@ -75,7 +75,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   U1TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return U1RXBUF;
 }
 

--- a/bsp/boards/z1/uart.c
+++ b/bsp/boards/z1/uart.c
@@ -47,19 +47,19 @@ void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb) {
    uart_vars.rxCb = rxCb;
 }
 
-void    uart_enableInterrupts(){
+void    uart_enableInterrupts(void) {
   UC0IE    |=  (UCA0RXIE  | UCA0TXIE);  
 }
 
-void    uart_disableInterrupts(){
+void    uart_disableInterrupts(void) {
   UC0IE &= ~(UCA0RXIE | UCA0TXIE);
 }
 
-void    uart_clearRxInterrupts(){
+void    uart_clearRxInterrupts(void) {
   UC0IFG   &= ~(UCA0RXIFG);
 }
 
-void    uart_clearTxInterrupts(){
+void    uart_clearTxInterrupts(void) {
   UC0IFG   &= ~(UCA0TXIFG);
 }
 
@@ -67,7 +67,7 @@ void    uart_writeByte(uint8_t byteToWrite){
   UCA0TXBUF = byteToWrite;
 }
 
-uint8_t uart_readByte(){
+uint8_t uart_readByte(void) {
   return UCA0RXBUF;
 }
 

--- a/bsp/chips/at86rf215/radio.c
+++ b/bsp/chips/at86rf215/radio.c
@@ -67,7 +67,7 @@ void radio_change_size(uint16_t* size){
     *size = sizes[i%4];
     i++;
 }
-void radio_change_modulation(){
+void radio_change_modulation(void) {
     static int mod_list = 1;
     at86rf215_spiStrobe(CMD_RF_TRXOFF);
     while(at86rf215_status() != RF_STATE_TRXOFF);

--- a/bsp/chips/at86rf231/radio.c
+++ b/bsp/chips/at86rf231/radio.c
@@ -223,7 +223,7 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
 //=========================== private =========================================
 
 
-uint8_t radio_spiReadRadioInfo(){
+uint8_t radio_spiReadRadioInfo(void) {
    uint8_t              spi_tx_buffer[3];
    uint8_t              spi_rx_buffer[3];
 

--- a/bsp/chips/at86rf233/radio.c
+++ b/bsp/chips/at86rf233/radio.c
@@ -273,7 +273,7 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
 //=========================== private =========================================
 
 
-uint8_t radio_spiReadRadioInfo(){
+uint8_t radio_spiReadRadioInfo(void) {
    uint8_t              spi_tx_buffer[3];
    uint8_t              spi_rx_buffer[3];
 

--- a/openapps/cstorm/cstorm.c
+++ b/openapps/cstorm/cstorm.c
@@ -151,7 +151,7 @@ owerror_t cstorm_receive(
 \note timer fired, but we don't want to execute task in ISR mode instead, push
    task to scheduler with CoAP priority, and let scheduler take care of it.
 */
-void cstorm_timer_cb(){
+void cstorm_timer_cb(void) {
    scheduler_push_task(cstorm_task_cb,TASKPRIO_COAP);
 }
 

--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -111,7 +111,7 @@ void ieee154e_init(void) {
     memset(&ieee154e_vars,0,sizeof(ieee154e_vars_t));
     memset(&ieee154e_dbg,0,sizeof(ieee154e_dbg_t));
     
-    ieee154e_vars.singleChannel     = 0; // 0 means channel hopping
+    ieee154e_vars.singleChannel     = 26; // 0 means channel hopping
     ieee154e_vars.isAckEnabled      = TRUE;
     ieee154e_vars.isSecurityEnabled = FALSE;
     ieee154e_vars.slotDuration      = TsSlotDuration;
@@ -2233,7 +2233,7 @@ port_INLINE void incrementAsnOffset(void) {
    ieee154e_vars.asnOffset   = (ieee154e_vars.asnOffset+1)%16;
 }
 
-port_INLINE void ieee154e_resetAsn(){
+port_INLINE void ieee154e_resetAsn(void) {
     // reset slotoffset
     ieee154e_vars.slotOffset     = 0;
     ieee154e_vars.asnOffset      = 0;
@@ -2528,7 +2528,7 @@ void ieee154e_setSlotDuration(uint16_t duration){
     ieee154e_vars.slotDuration = duration;
 }
 
-uint16_t ieee154e_getSlotDuration(){
+uint16_t ieee154e_getSlotDuration(void) {
     return ieee154e_vars.slotDuration;
 }
 
@@ -2903,6 +2903,6 @@ void endSlot(void) {
     changeState(S_SLEEP);
 }
 
-bool ieee154e_isSynch(){
+bool ieee154e_isSynch(void) {
     return ieee154e_vars.isSync;
 }

--- a/openstack/02b-MAChigh/schedule.c
+++ b/openstack/02b-MAChigh/schedule.c
@@ -518,7 +518,7 @@ void schedule_removeAllCells(
     }
 }
 
-scheduleEntry_t* schedule_getCurrentScheduleEntry(){
+scheduleEntry_t* schedule_getCurrentScheduleEntry(void) {
     return schedule_vars.currentScheduleEntry;
 }
 
@@ -544,7 +544,7 @@ uint8_t schedule_getNumOfSlotsByType(cellType_t type){
    return returnVal;
 }
 
-uint8_t schedule_getNumberOfFreeEntries(){
+uint8_t schedule_getNumberOfFreeEntries(void) {
    uint8_t i; 
    uint8_t counter;
    

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -629,7 +629,7 @@ void sixtop_timeout_timer_cb(opentimers_id_t id) {
 
 //======= EB/KA task
 
-void timer_sixtop_sendEb_fired(){
+void timer_sixtop_sendEb_fired(void) {
     
     uint16_t newPeriod;
     // current period 

--- a/openstack/03b-IPv6/icmpv6rpl.c
+++ b/openstack/03b-IPv6/icmpv6rpl.c
@@ -194,7 +194,7 @@ void  icmpv6rpl_writeDODAGid(uint8_t* dodagid) {
    icmpv6rpl_vars.fDodagidWritten = 1;
 }
 
-uint8_t icmpv6rpl_getRPLIntanceID(){
+uint8_t icmpv6rpl_getRPLIntanceID(void) {
    return icmpv6rpl_vars.dao.rplinstanceId;
 }
                                                 

--- a/openstack/cross-layers/openqueue.c
+++ b/openstack/cross-layers/openqueue.c
@@ -250,7 +250,7 @@ OpenQueueEntry_t* openqueue_macGetDataPacket(open_addr_t* toNeighbor) {
    return NULL;
 }
 
-bool openqueue_isHighPriorityEntryEnough(){
+bool openqueue_isHighPriorityEntryEnough(void) {
     uint8_t i;
     uint8_t numberOfEntry;
     

--- a/projects/common/03oos_sniffer/03oos_sniffer.c
+++ b/projects/common/03oos_sniffer/03oos_sniffer.c
@@ -172,7 +172,7 @@ void cb_timer(opentimers_id_t id) {
 }
 
 // ================================ task =======================================
-void task_uploadPacket(){
+void task_uploadPacket(void) {
     openserial_printSniffedPacket(
         &(app_vars.packet[0]),
         app_vars.packet_len,


### PR DESCRIPTION
Continuation of #407 and #410. I'm sorry for the single PRs, this wasn't on purpose