### PR TITLE
drivers/openserial: fix unused parameter `id`

### DIFF
--- a/drivers/common/openserial.c
+++ b/drivers/common/openserial.c
@@ -789,6 +789,7 @@ void openserial_handleCommands(void){
 //===== misc
 
 void openserial_board_reset_cb(opentimers_id_t id) {
+    (void)id;
     board_reset();
 }
 


### PR DESCRIPTION
`id` is not used. When compiled from RIOT this throws an `unused parameter` error.