### PR TITLE
FW-613. do not compile for telosb, wsn430v13b and wsn430v14 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ script:
 - scons board=z1                                      toolchain=mspgcc verbose=1 oos_macpong
 - scons board=iot-lab_M3                              toolchain=armgcc verbose=1 oos_macpong
 - scons board=iot-lab_A8-M3                           toolchain=armgcc verbose=1 oos_macpong
-- scons board=telosb                                  toolchain=mspgcc verbose=1 oos_openwsn
-- scons board=telosb              kernel=freertos     toolchain=mspgcc verbose=1 oos_openwsn
+# - scons board=telosb                                  toolchain=mspgcc verbose=1 oos_openwsn
+# - scons board=telosb              kernel=freertos     toolchain=mspgcc verbose=1 oos_openwsn
 - scons board=openmote-cc2538                         toolchain=armgcc verbose=1 oos_openwsn
 - scons board=openmote-cc2538     goldenImage=sniffer toolchain=armgcc verbose=1 oos_sniffer
 - scons board=openmote-cc2538     goldenImage=root    toolchain=armgcc verbose=1 oos_openwsn
 - scons board=openmote-b                              toolchain=armgcc verbose=1 oos_openwsn
-- scons board=wsn430v14                               toolchain=mspgcc verbose=1 oos_openwsn
-- scons board=wsn430v13b                              toolchain=mspgcc verbose=1 oos_openwsn
+# - scons board=wsn430v14                               toolchain=mspgcc verbose=1 oos_openwsn
+# - scons board=wsn430v13b                              toolchain=mspgcc verbose=1 oos_openwsn
 - scons board=gina                                    toolchain=mspgcc verbose=1 oos_openwsn
 - scons board=z1                                      toolchain=mspgcc verbose=1 oos_openwsn
 - scons board=python                                  toolchain=gcc    verbose=1 oos_openwsn


### PR DESCRIPTION
The microcontroller ROM size is limited for telosb, wsn430v13b and wsn430v14 platform. Do not compile oos_openwsn project for those platforms.