### PR TITLE
Make leds_increment to handle overflow

### DIFF
--- a/bsp/boards/telosb/leds.c
+++ b/bsp/boards/telosb/leds.c
@@ -127,6 +127,10 @@ void    leds_increment(void) {
       leds_on = 0x01;
    } else {
       leds_on += 1;
+      if ((leds_on & 0x08)!=0) {
+         leds_on &= ~0x08;
+         leds_on |=  0x01;                       // handle overflow
+      }
    }
    // apply updated LED state
    leds_on <<= 4;                                // send back to position 4

--- a/bsp/boards/telosb/leds.c
+++ b/bsp/boards/telosb/leds.c
@@ -128,8 +128,7 @@ void    leds_increment(void) {
    } else {
       leds_on += 1;
       if ((leds_on & 0x08)!=0) {
-         leds_on &= ~0x08;
-         leds_on |=  0x01;                       // handle overflow
+         leds_on &= ~0x08;                       // handle overflow
       }
    }
    // apply updated LED state


### PR DESCRIPTION
While leds_circular_shift handles overflow, it seems that leds_increment doesn't, so I just copied the corresponding part of the source code.