### PR TITLE
Make leds_increment to handle overflow

### DIFF
--- a/bsp/boards/telosb/leds.c
+++ b/bsp/boards/telosb/leds.c
@@ -127,6 +127,9 @@ void    leds_increment(void) {
       leds_on = 0x01;
    } else {
       leds_on += 1;
+      if ((leds_on & 0x08)!=0) {
+         leds_on &= ~0x08;                       // handle overflow
+      }
    }
    // apply updated LED state
    leds_on <<= 4;                                // send back to position 4


### PR DESCRIPTION
While leds_circular_shift handles overflow, it seems that leds_increment doesn't, so I just copied the corresponding part of the source code.