### PR TITLE
Configure TX power through radio API

### DIFF
--- a/bsp/boards/openmote-b-24ghz/radio.c
+++ b/bsp/boards/openmote-b-24ghz/radio.c
@@ -40,10 +40,27 @@
 typedef struct {
    radio_capture_cbt         startFrame_cb;
    radio_capture_cbt         endFrame_cb;
-   radio_state_t             state; 
+   radio_state_t             state;
 } radio_vars_t;
 
 radio_vars_t radio_vars;
+
+static const radio_output_power_config_t cc2538_output_power[] = {
+   {  7, 0xFF },
+   {  5, 0xED },
+   {  3, 0xD5 },
+   {  1, 0xC5 },
+   {  0, 0xB6 },
+   { -1, 0xB0 },
+   { -3, 0xA1 },
+   { -5, 0x91 },
+   { -7, 0x88 },
+   { -9, 0x72 },
+   {-11, 0x62 },
+   {-13, 0x58 },
+   {-15, 0x42 },
+   {-24, 0x00 },
+};
 
 //=========================== prototypes ======================================
 
@@ -61,21 +78,21 @@ void     radio_isr_internal(void);
 //===== admin
 
 void radio_init(void) {
-   
+
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_STOPPED;
    //flush fifos
    CC2538_RF_CSP_ISFLUSHRX();
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    radio_off();
-   
+
    //disable radio interrupts
    disable_radio_interrupts();
-   
+
    /*
    This CORR_THR value should be changed to 0x14 before attempting RX. Testing has shown that
    too many false frames are received if the reset value is used. Make it more likely to detect
@@ -85,26 +102,26 @@ void radio_init(void) {
    */
    HWREG(RFCORE_XREG_MDMCTRL1)    = 0x14;
    /* tuning adjustments for optimal radio performance; details available in datasheet */
-   
+
    HWREG(RFCORE_XREG_RXCTRL)      = 0x3F;
    /* Adjust current in synthesizer; details available in datasheet. */
    HWREG(RFCORE_XREG_FSCTRL)      = 0x55;
-   
+
      /* Makes sync word detection less likely by requiring two zero symbols before the sync word.
       * details available in datasheet.
       */
    HWREG(RFCORE_XREG_MDMCTRL0)    = 0x85;
-   
+
    /* Adjust current in VCO; details available in datasheet. */
    HWREG(RFCORE_XREG_FSCAL1)      = 0x01;
    /* Adjust target value for AGC control loop; details available in datasheet. */
    HWREG(RFCORE_XREG_AGCCTRL1)    = 0x15;
-   
+
    /* Tune ADC performance, details available in datasheet. */
    HWREG(RFCORE_XREG_ADCTEST0)    = 0x10;
    HWREG(RFCORE_XREG_ADCTEST1)    = 0x0E;
    HWREG(RFCORE_XREG_ADCTEST2)    = 0x03;
-   
+
    //update CCA register to -81db as indicated by manual.. won't be used..
    HWREG(RFCORE_XREG_CCACTRL0)    = 0xF8;
    /*
@@ -114,7 +131,7 @@ void radio_init(void) {
    HWREG(RFCORE_XREG_TXFILTCFG)   = 0x09;    /** TX anti-aliasing filter bandwidth */
    HWREG(RFCORE_XREG_AGCCTRL1)    = 0x15;     /** AGC target value */
    HWREG(ANA_REGS_O_IVCTRL)       = 0x0B;        /** Bias currents */
-   
+
    /* disable the CSPT register compare function */
    HWREG(RFCORE_XREG_CSPT)        = 0xFFUL;
    /*
@@ -123,33 +140,33 @@ void radio_init(void) {
     * RX and TX modes with FIFOs
     */
    HWREG(RFCORE_XREG_FRMCTRL0)    = RFCORE_XREG_FRMCTRL0_AUTOCRC;
-   
+
    //poipoi disable frame filtering by now.. sniffer mode.
    HWREG(RFCORE_XREG_FRMFILT0)   &= ~RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN;
-   
+
    /* Disable source address matching and autopend */
    HWREG(RFCORE_XREG_SRCMATCH)    = 0;
-   
+
    /* MAX FIFOP threshold */
    HWREG(RFCORE_XREG_FIFOPCTRL)   = CC2538_RF_MAX_PACKET_LEN;
-   
+
    HWREG(RFCORE_XREG_TXPOWER)     = CC2538_RF_TX_POWER;
    HWREG(RFCORE_XREG_FREQCTRL)    = CC2538_RF_CHANNEL_MIN;
-   
+
    /* Enable RF interrupts  see page 751  */
    // enable_radio_interrupts();
-   
+
    //register interrupt
    IntRegister(INT_RFCORERTX, radio_isr_internal);
    IntRegister(INT_RFCOREERR, radio_error_isr);
-   
+
    IntEnable(INT_RFCORERTX);
-   
+
    /* Enable all RF Error interrupts */
    HWREG(RFCORE_XREG_RFERRM)      = RFCORE_XREG_RFERRM_RFERRM_M; //all errors
    IntEnable(INT_RFCOREERR);
    //radio_on();
-   
+
    // change state
    radio_vars.state               = RADIOSTATE_RFOFF;
 }
@@ -167,11 +184,11 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 void radio_reset(void) {
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
-   
+
    //flush fifos
    CC2538_RF_CSP_ISFLUSHRX();
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    /* Don't turn off if we are off as this will trigger a Strobe Error */
    if(HWREG(RFCORE_XREG_RXENABLE) != 0) {
       CC2538_RF_CSP_ISRFOFF();
@@ -191,15 +208,33 @@ void radio_setFrequency(uint8_t frequency) {
    if((frequency < CC2538_RF_CHANNEL_MIN) || (frequency > CC2538_RF_CHANNEL_MAX)) {
       while(1);
    }
-   
+
    /* Changes to FREQCTRL take effect after the next recalibration */
    HWREG(RFCORE_XREG_FREQCTRL) = (CC2538_RF_CHANNEL_MIN
       + (frequency - CC2538_RF_CHANNEL_MIN) * CC2538_RF_CHANNEL_SPACING);
-   
+
    //radio_on();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
+}
+
+// configure the radio to output at least @power dBm, or the maximum available power
+void radio_setTxPower(int8_t power) {
+   uint8_t               i;
+   uint8_t               reg_val;
+
+   // loop to find at-least :power: dBm in the look-up table
+   // if the max output power of a chip is higher than :power:, we configure the maximum
+   reg_val = cc2538_output_power[0].register_val;
+   for(i = sizeof(cc2538_output_power) / sizeof(radio_output_power_config_t) - 1; i >= 0; --i) {
+     if(power <= cc2538_output_power[i].power_dbm) {
+       reg_val = cc2538_output_power[i].register_val;
+       break;
+     }
+   }
+
+   HWREG(RFCORE_XREG_TXPOWER)     = reg_val;
 }
 
 void radio_rfOn(void) {
@@ -207,7 +242,7 @@ void radio_rfOn(void) {
 }
 
 void radio_rfOff(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
    radio_off();
@@ -216,7 +251,7 @@ void radio_rfOff(void) {
    leds_radio_off();
    //enable radio interrupts
    disable_radio_interrupts();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_RFOFF;
 }
@@ -225,49 +260,49 @@ void radio_rfOff(void) {
 
 void radio_loadPacket(uint8_t* packet, uint16_t len) {
    uint8_t i=0;
-   
+
    // change state
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
-   
+
    // load packet in TXFIFO
    /*
    When we transmit in very quick bursts, make sure previous transmission
    is not still in progress before re-writing to the TX FIFO
    */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
-   
+
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    /* Send the phy length byte first */
     HWREG(RFCORE_SFR_RFDATA) = len; //crc len is included
-   
+
    for(i = 0; i < len; i++) {
       HWREG(RFCORE_SFR_RFDATA) = packet[i];
    }
-   
+
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
 void radio_txEnable(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
-   
+
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    //do nothing -- radio is activated by the strobe on rx or tx
    //radio_rfOn();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
 void radio_txNow(void) {
    PORT_TIMER_WIDTH count;
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
 
@@ -290,17 +325,17 @@ void radio_txNow(void) {
 //===== RX
 
 void radio_rxEnable(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
-   
+
    //enable radio interrupts
-   
+
    // do nothing as we do not want to receive anything yet.
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_LISTENING;
 }
@@ -308,11 +343,11 @@ void radio_rxEnable(void) {
 void radio_rxNow(void) {
    //empty buffer before receiving
    //CC2538_RF_CSP_ISFLUSHRX();
-   
+
    //enable radio interrupts
    CC2538_RF_CSP_ISFLUSHRX();
    enable_radio_interrupts();
-   
+
    CC2538_RF_CSP_ISRXON();
    // busy wait until radio really listening
    while(!((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_RX_ACTIVE)));
@@ -325,49 +360,49 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
                             uint8_t* pLqi,
                                bool* pCrc) {
    uint8_t crc_corr,i;
-   
+
    uint8_t len=0;
-   
+
    /* Check the length */
    len = HWREG(RFCORE_SFR_RFDATA); //first byte is len
-   
-   
+
+
    /* Check for validity */
    if(len > CC2538_RF_MAX_PACKET_LEN) {
       /* wrong len */
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
-   
+
+
    if(len <= CC2538_RF_MIN_PACKET_LEN) {
       //too short
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
+
    //check if this fits to the buffer
    if(len > maxBufLen) {
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
+
    // when reading the packet from the RX buffer, you get the following:
    // - *[1B]     length byte
    // -  [0-125B] packet (excluding CRC)
    // -  [1B]     RSSI
    // - *[2B]     CRC
-   
+
    //skip first byte is len
    for(i = 0; i < len - 2; i++) {
       pBufRead[i] = HWREG(RFCORE_SFR_RFDATA);
    }
-   
+
    *pRssi     = ((int8_t)(HWREG(RFCORE_SFR_RFDATA)) - RSSI_OFFSET);
    crc_corr   = HWREG(RFCORE_SFR_RFDATA);
    *pCrc      = crc_corr & CRC_BIT_MASK;
    *pLenRead  = len;
-   
+
    //flush it
    CC2538_RF_CSP_ISFLUSHRX();
 }
@@ -398,7 +433,7 @@ void radio_off(void){
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
    //CC2538_RF_CSP_ISFLUSHRX();
-   
+
    /* Don't turn off if we are off as this will trigger a Strobe Error */
    if(HWREG(RFCORE_XREG_RXENABLE) != 0) {
       CC2538_RF_CSP_ISRFOFF();
@@ -436,22 +471,22 @@ kick_scheduler_t radio_isr(void) {
 void radio_isr_internal(void) {
    volatile PORT_TIMER_WIDTH capturedTime;
    uint8_t  irq_status0,irq_status1;
-   
+
    debugpins_isr_set();
-   
+
    // capture the time
    capturedTime = sctimer_readCounter();
-   
+
    // reading IRQ_STATUS
    irq_status0 = HWREG(RFCORE_SFR_RFIRQF0);
    irq_status1 = HWREG(RFCORE_SFR_RFIRQF1);
-   
+
    IntPendClear(INT_RFCORERTX);
-   
+
    //clear interrupt
    HWREG(RFCORE_SFR_RFIRQF0) = 0;
    HWREG(RFCORE_SFR_RFIRQF1) = 0;
-   
+
    //STATUS0 Register
    // start of frame event
    if ((irq_status0 & RFCORE_SFR_RFIRQF0_SFD) == RFCORE_SFR_RFIRQF0_SFD) {
@@ -467,7 +502,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    //or RXDONE is full -- we have a packet.
    if (((irq_status0 & RFCORE_SFR_RFIRQF0_RXPKTDONE) ==  RFCORE_SFR_RFIRQF0_RXPKTDONE)) {
       // change state
@@ -482,7 +517,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    // or FIFOP is full -- we have a packet.
    if (((irq_status0 & RFCORE_SFR_RFIRQF0_FIFOP) ==  RFCORE_SFR_RFIRQF0_FIFOP)) {
       // change state
@@ -497,7 +532,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    //STATUS1 Register
    // end of frame event --either end of tx .
    if (((irq_status1 & RFCORE_SFR_RFIRQF1_TXDONE) == RFCORE_SFR_RFIRQF1_TXDONE)) {
@@ -514,15 +549,15 @@ void radio_isr_internal(void) {
       }
    }
    debugpins_isr_clr();
-   
+
    return;
 }
 
 void radio_error_isr(void){
    uint8_t rferrm;
-   
+
    rferrm = (uint8_t)HWREG(RFCORE_XREG_RFERRM);
-   
+
    if ((HWREG(RFCORE_XREG_RFERRM) & (((0x02)<<RFCORE_XREG_RFERRM_RFERRM_S)&RFCORE_XREG_RFERRM_RFERRM_M)) & ((uint32_t)rferrm))
    {
       HWREG(RFCORE_XREG_RFERRM) = ~(((0x02)<<RFCORE_XREG_RFERRM_RFERRM_S)&RFCORE_XREG_RFERRM_RFERRM_M);

--- a/bsp/boards/openmote-b/radio.c
+++ b/bsp/boards/openmote-b/radio.c
@@ -40,7 +40,7 @@
 typedef struct {
    radio_capture_cbt         startFrame_cb;
    radio_capture_cbt         endFrame_cb;
-   radio_state_t             state; 
+   radio_state_t             state;
 } radio_vars_t;
 
 radio_vars_t radio_vars;
@@ -61,21 +61,21 @@ void     radio_isr_internal(void);
 //===== admin
 
 void radio_init(void) {
-   
+
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_STOPPED;
    //flush fifos
    CC2538_RF_CSP_ISFLUSHRX();
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    radio_off();
-   
+
    //disable radio interrupts
    disable_radio_interrupts();
-   
+
    /*
    This CORR_THR value should be changed to 0x14 before attempting RX. Testing has shown that
    too many false frames are received if the reset value is used. Make it more likely to detect
@@ -85,26 +85,26 @@ void radio_init(void) {
    */
    HWREG(RFCORE_XREG_MDMCTRL1)    = 0x14;
    /* tuning adjustments for optimal radio performance; details available in datasheet */
-   
+
    HWREG(RFCORE_XREG_RXCTRL)      = 0x3F;
    /* Adjust current in synthesizer; details available in datasheet. */
    HWREG(RFCORE_XREG_FSCTRL)      = 0x55;
-   
+
      /* Makes sync word detection less likely by requiring two zero symbols before the sync word.
       * details available in datasheet.
       */
    HWREG(RFCORE_XREG_MDMCTRL0)    = 0x85;
-   
+
    /* Adjust current in VCO; details available in datasheet. */
    HWREG(RFCORE_XREG_FSCAL1)      = 0x01;
    /* Adjust target value for AGC control loop; details available in datasheet. */
    HWREG(RFCORE_XREG_AGCCTRL1)    = 0x15;
-   
+
    /* Tune ADC performance, details available in datasheet. */
    HWREG(RFCORE_XREG_ADCTEST0)    = 0x10;
    HWREG(RFCORE_XREG_ADCTEST1)    = 0x0E;
    HWREG(RFCORE_XREG_ADCTEST2)    = 0x03;
-   
+
    //update CCA register to -81db as indicated by manual.. won't be used..
    HWREG(RFCORE_XREG_CCACTRL0)    = 0xF8;
    /*
@@ -114,7 +114,7 @@ void radio_init(void) {
    HWREG(RFCORE_XREG_TXFILTCFG)   = 0x09;    /** TX anti-aliasing filter bandwidth */
    HWREG(RFCORE_XREG_AGCCTRL1)    = 0x15;     /** AGC target value */
    HWREG(ANA_REGS_O_IVCTRL)       = 0x0B;        /** Bias currents */
-   
+
    /* disable the CSPT register compare function */
    HWREG(RFCORE_XREG_CSPT)        = 0xFFUL;
    /*
@@ -123,33 +123,33 @@ void radio_init(void) {
     * RX and TX modes with FIFOs
     */
    HWREG(RFCORE_XREG_FRMCTRL0)    = RFCORE_XREG_FRMCTRL0_AUTOCRC;
-   
+
    //poipoi disable frame filtering by now.. sniffer mode.
    HWREG(RFCORE_XREG_FRMFILT0)   &= ~RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN;
-   
+
    /* Disable source address matching and autopend */
    HWREG(RFCORE_XREG_SRCMATCH)    = 0;
-   
+
    /* MAX FIFOP threshold */
    HWREG(RFCORE_XREG_FIFOPCTRL)   = CC2538_RF_MAX_PACKET_LEN;
-   
+
    HWREG(RFCORE_XREG_TXPOWER)     = CC2538_RF_TX_POWER;
    HWREG(RFCORE_XREG_FREQCTRL)    = CC2538_RF_CHANNEL_MIN;
-   
+
    /* Enable RF interrupts  see page 751  */
    // enable_radio_interrupts();
-   
+
    //register interrupt
    IntRegister(INT_RFCORERTX, radio_isr_internal);
    IntRegister(INT_RFCOREERR, radio_error_isr);
-   
+
    IntEnable(INT_RFCORERTX);
-   
+
    /* Enable all RF Error interrupts */
    HWREG(RFCORE_XREG_RFERRM)      = RFCORE_XREG_RFERRM_RFERRM_M; //all errors
    IntEnable(INT_RFCOREERR);
    //radio_on();
-   
+
    // change state
    radio_vars.state               = RADIOSTATE_RFOFF;
 }
@@ -167,11 +167,11 @@ void radio_setEndFrameCb(radio_capture_cbt cb) {
 void radio_reset(void) {
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
-   
+
    //flush fifos
    CC2538_RF_CSP_ISFLUSHRX();
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    /* Don't turn off if we are off as this will trigger a Strobe Error */
    if(HWREG(RFCORE_XREG_RXENABLE) != 0) {
       CC2538_RF_CSP_ISRFOFF();
@@ -191,15 +191,19 @@ void radio_setFrequency(uint8_t frequency) {
    if((frequency < CC2538_RF_CHANNEL_MIN) || (frequency > CC2538_RF_CHANNEL_MAX)) {
       while(1);
    }
-   
+
    /* Changes to FREQCTRL take effect after the next recalibration */
    HWREG(RFCORE_XREG_FREQCTRL) = (CC2538_RF_CHANNEL_MIN
       + (frequency - CC2538_RF_CHANNEL_MIN) * CC2538_RF_CHANNEL_SPACING);
-   
+
    //radio_on();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
+}
+
+void radio_setTxPower(int8_t power) {
+    // TODO
 }
 
 void radio_rfOn(void) {
@@ -207,7 +211,7 @@ void radio_rfOn(void) {
 }
 
 void radio_rfOff(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
    radio_off();
@@ -216,7 +220,7 @@ void radio_rfOff(void) {
    leds_radio_off();
    //enable radio interrupts
    disable_radio_interrupts();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_RFOFF;
 }
@@ -225,49 +229,49 @@ void radio_rfOff(void) {
 
 void radio_loadPacket(uint8_t* packet, uint16_t len) {
    uint8_t i=0;
-   
+
    // change state
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
-   
+
    // load packet in TXFIFO
    /*
    When we transmit in very quick bursts, make sure previous transmission
    is not still in progress before re-writing to the TX FIFO
    */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
-   
+
    CC2538_RF_CSP_ISFLUSHTX();
-   
+
    /* Send the phy length byte first */
     HWREG(RFCORE_SFR_RFDATA) = len; //crc len is included
-   
+
    for(i = 0; i < len; i++) {
       HWREG(RFCORE_SFR_RFDATA) = packet[i];
    }
-   
+
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
 
 void radio_txEnable(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
-   
+
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    //do nothing -- radio is activated by the strobe on rx or tx
    //radio_rfOn();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
 
 void radio_txNow(void) {
    PORT_TIMER_WIDTH count;
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
 
@@ -290,17 +294,17 @@ void radio_txNow(void) {
 //===== RX
 
 void radio_rxEnable(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
-   
+
    //enable radio interrupts
-   
+
    // do nothing as we do not want to receive anything yet.
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_LISTENING;
 }
@@ -308,11 +312,11 @@ void radio_rxEnable(void) {
 void radio_rxNow(void) {
    //empty buffer before receiving
    //CC2538_RF_CSP_ISFLUSHRX();
-   
+
    //enable radio interrupts
    CC2538_RF_CSP_ISFLUSHRX();
    enable_radio_interrupts();
-   
+
    CC2538_RF_CSP_ISRXON();
    // busy wait until radio really listening
    while(!((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_RX_ACTIVE)));
@@ -325,49 +329,49 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
                             uint8_t* pLqi,
                                bool* pCrc) {
    uint8_t crc_corr,i;
-   
+
    uint8_t len=0;
-   
+
    /* Check the length */
    len = HWREG(RFCORE_SFR_RFDATA); //first byte is len
-   
-   
+
+
    /* Check for validity */
    if(len > CC2538_RF_MAX_PACKET_LEN) {
       /* wrong len */
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
-   
+
+
    if(len <= CC2538_RF_MIN_PACKET_LEN) {
       //too short
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
+
    //check if this fits to the buffer
    if(len > maxBufLen) {
       CC2538_RF_CSP_ISFLUSHRX();
       return;
    }
-   
+
    // when reading the packet from the RX buffer, you get the following:
    // - *[1B]     length byte
    // -  [0-125B] packet (excluding CRC)
    // -  [1B]     RSSI
    // - *[2B]     CRC
-   
+
    //skip first byte is len
    for(i = 0; i < len - 2; i++) {
       pBufRead[i] = HWREG(RFCORE_SFR_RFDATA);
    }
-   
+
    *pRssi     = ((int8_t)(HWREG(RFCORE_SFR_RFDATA)) - RSSI_OFFSET);
    crc_corr   = HWREG(RFCORE_SFR_RFDATA);
    *pCrc      = crc_corr & CRC_BIT_MASK;
    *pLenRead  = len;
-   
+
    //flush it
    CC2538_RF_CSP_ISFLUSHRX();
 }
@@ -398,7 +402,7 @@ void radio_off(void){
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
    //CC2538_RF_CSP_ISFLUSHRX();
-   
+
    /* Don't turn off if we are off as this will trigger a Strobe Error */
    if(HWREG(RFCORE_XREG_RXENABLE) != 0) {
       CC2538_RF_CSP_ISRFOFF();
@@ -436,22 +440,22 @@ kick_scheduler_t radio_isr(void) {
 void radio_isr_internal(void) {
    volatile PORT_TIMER_WIDTH capturedTime;
    uint8_t  irq_status0,irq_status1;
-   
+
    debugpins_isr_set();
-   
+
    // capture the time
    capturedTime = sctimer_readCounter();
-   
+
    // reading IRQ_STATUS
    irq_status0 = HWREG(RFCORE_SFR_RFIRQF0);
    irq_status1 = HWREG(RFCORE_SFR_RFIRQF1);
-   
+
    IntPendClear(INT_RFCORERTX);
-   
+
    //clear interrupt
    HWREG(RFCORE_SFR_RFIRQF0) = 0;
    HWREG(RFCORE_SFR_RFIRQF1) = 0;
-   
+
    //STATUS0 Register
    // start of frame event
    if ((irq_status0 & RFCORE_SFR_RFIRQF0_SFD) == RFCORE_SFR_RFIRQF0_SFD) {
@@ -467,7 +471,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    //or RXDONE is full -- we have a packet.
    if (((irq_status0 & RFCORE_SFR_RFIRQF0_RXPKTDONE) ==  RFCORE_SFR_RFIRQF0_RXPKTDONE)) {
       // change state
@@ -482,7 +486,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    // or FIFOP is full -- we have a packet.
    if (((irq_status0 & RFCORE_SFR_RFIRQF0_FIFOP) ==  RFCORE_SFR_RFIRQF0_FIFOP)) {
       // change state
@@ -497,7 +501,7 @@ void radio_isr_internal(void) {
          while(1);
       }
    }
-   
+
    //STATUS1 Register
    // end of frame event --either end of tx .
    if (((irq_status1 & RFCORE_SFR_RFIRQF1_TXDONE) == RFCORE_SFR_RFIRQF1_TXDONE)) {
@@ -514,15 +518,15 @@ void radio_isr_internal(void) {
       }
    }
    debugpins_isr_clr();
-   
+
    return;
 }
 
 void radio_error_isr(void){
    uint8_t rferrm;
-   
+
    rferrm = (uint8_t)HWREG(RFCORE_XREG_RFERRM);
-   
+
    if ((HWREG(RFCORE_XREG_RFERRM) & (((0x02)<<RFCORE_XREG_RFERRM_RFERRM_S)&RFCORE_XREG_RFERRM_RFERRM_M)) & ((uint32_t)rferrm))
    {
       HWREG(RFCORE_XREG_RFERRM) = ~(((0x02)<<RFCORE_XREG_RFERRM_RFERRM_S)&RFCORE_XREG_RFERRM_RFERRM_M);

--- a/bsp/boards/openmote-cc2538/cc2538rf.h
+++ b/bsp/boards/openmote-cc2538/cc2538rf.h
@@ -16,7 +16,7 @@
  *---------------------------------------------------------------------------*/
 /* Constants */
 #define CC2538_RF_CCA_THRES_USER_GUIDE 0xF8
-#define CC2538_RF_TX_POWER_RECOMMENDED 0xD5 /* TODO: Check value */
+#define CC2538_RF_TX_POWER_RECOMMENDED 0xD5 /* 3 dBm */
 #define CC2538_RF_CHANNEL_MIN            11 //poipoi -- in fact is sending on 0x17 check that.
 #define CC2538_RF_CHANNEL_MAX            26
 #define CC2538_RF_CHANNEL_SPACING         5

--- a/bsp/boards/openmote-cc2538/radio.c
+++ b/bsp/boards/openmote-cc2538/radio.c
@@ -45,6 +45,23 @@ typedef struct {
 
 radio_vars_t radio_vars;
 
+static const radio_output_power_config_t cc2538_output_power[] = {
+   {  7, 0xFF },
+   {  5, 0xED },
+   {  3, 0xD5 },
+   {  1, 0xC5 },
+   {  0, 0xB6 },
+   { -1, 0xB0 },
+   { -3, 0xA1 },
+   { -5, 0x91 },
+   { -7, 0x88 },
+   { -9, 0x72 },
+   {-11, 0x62 },
+   {-13, 0x58 },
+   {-15, 0x42 },
+   {-24, 0x00 },
+};
+
 //=========================== prototypes ======================================
 
 void     enable_radio_interrupts(void);
@@ -200,6 +217,24 @@ void radio_setFrequency(uint8_t frequency) {
 
    // change state
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
+}
+
+// configure the radio to output at least @power dBm, or the maximum available power
+void radio_setTxPower(int8_t power) {
+   uint8_t               i;
+   uint8_t               reg_val;
+
+   // loop to find at-least :power: dBm in the look-up table
+   // if the max output power of a chip is higher than :power:, we configure the maximum
+   reg_val = cc2538_output_power[0].register_val;
+   for(i = sizeof(cc2538_output_power) / sizeof(radio_output_power_config_t) - 1; i >= 0; --i) {
+     if(power <= cc2538_output_power[i].power_dbm) {
+       reg_val = cc2538_output_power[i].register_val;
+       break;
+     }
+   }
+
+   HWREG(RFCORE_XREG_TXPOWER)     = reg_val;
 }
 
 void radio_rfOn(void) {

--- a/bsp/boards/python/radio_obj.c
+++ b/bsp/boards/python/radio_obj.c
@@ -14,26 +14,26 @@
 
 
 void radio_setStartFrameCb(OpenMote* self, radio_capture_cbt cb) {
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_setStartFrameCb(cb=0x%x)... \n",self,cb);
 #endif
-   
+
    self->radio_icb.startFrame_cb  = cb;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
 }
 
 void radio_setEndFrameCb(OpenMote* self, radio_capture_cbt cb) {
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_setEndFrameCb(cb=0x%x)... \n",self,cb);
 #endif
-   
+
    self->radio_icb.endFrame_cb    = cb;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -45,11 +45,11 @@ void radio_setEndFrameCb(OpenMote* self, radio_capture_cbt cb) {
 
 void radio_init(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_init()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_init],NULL);
    if (result == NULL) {
@@ -57,7 +57,7 @@ void radio_init(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -67,11 +67,11 @@ void radio_init(OpenMote* self) {
 
 void radio_reset(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_reset()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_reset],NULL);
    if (result == NULL) {
@@ -79,7 +79,7 @@ void radio_reset(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -90,11 +90,11 @@ void radio_reset(OpenMote* self) {
 void radio_setFrequency(OpenMote* self, uint8_t frequency) {
    PyObject*   result;
    PyObject*   arglist;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_setFrequency(frequency=%d)... \n",self,frequency);
 #endif
-   
+
    // forward to Python
    arglist    = Py_BuildValue("(i)",frequency);
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_setFrequency],arglist);
@@ -104,19 +104,23 @@ void radio_setFrequency(OpenMote* self, uint8_t frequency) {
    }
    Py_DECREF(result);
    Py_DECREF(arglist);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
 }
 
+void radio_setTxPower(OpenMote* self, int8_t power) {
+    // TODO
+}
+
 void radio_rfOn(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_rfOn()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_rfOn],NULL);
    if (result == NULL) {
@@ -124,7 +128,7 @@ void radio_rfOn(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -132,11 +136,11 @@ void radio_rfOn(OpenMote* self) {
 
 void radio_rfOff(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_rfOff()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_rfOff],NULL);
    if (result == NULL) {
@@ -144,7 +148,7 @@ void radio_rfOff(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -159,11 +163,11 @@ void radio_loadPacket(OpenMote* self, uint8_t* packet, uint16_t len) {
    PyObject*   item;
    int8_t      i;
    int         res;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_loadPacket(len=%d)... \n",self,len);
 #endif
-   
+
    // forward to Python
    pkt        = PyList_New(len);
    for (i=0;i<len;i++) {
@@ -187,11 +191,11 @@ void radio_loadPacket(OpenMote* self, uint8_t* packet, uint16_t len) {
 
 void radio_txEnable(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_txEnable()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_txEnable],NULL);
    if (result == NULL) {
@@ -199,7 +203,7 @@ void radio_txEnable(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -207,11 +211,11 @@ void radio_txEnable(OpenMote* self) {
 
 void radio_txNow(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_txNow()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_txNow],NULL);
    if (result == NULL) {
@@ -219,7 +223,7 @@ void radio_txNow(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -229,11 +233,11 @@ void radio_txNow(OpenMote* self) {
 
 void radio_rxEnable(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_rxEnable()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_rxEnable],NULL);
    if (result == NULL) {
@@ -241,7 +245,7 @@ void radio_rxEnable(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -249,11 +253,11 @@ void radio_rxEnable(OpenMote* self) {
 
 void radio_rxNow(OpenMote* self) {
    PyObject*   result;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_rxNow()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_rxNow],NULL);
    if (result == NULL) {
@@ -261,7 +265,7 @@ void radio_rxNow(OpenMote* self) {
       return;
    }
    Py_DECREF(result);
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: ...done.\n",self);
 #endif
@@ -279,18 +283,18 @@ void radio_getReceivedFrame(OpenMote* self,
    PyObject*  subitem;
    int8_t     lenRead;
    int8_t     i;
-   
+
 #ifdef TRACE_ON
    printf("C@0x%x: radio_getReceivedFrame()... \n",self);
 #endif
-   
+
    // forward to Python
    result     = PyObject_CallObject(self->callback[MOTE_NOTIF_radio_getReceivedFrame],NULL);
    if (result == NULL) {
       printf("[CRITICAL] radio_getReceivedFrame() returned NULL\r\n");
       return;
    }
-   
+
    // verify
    if (!PySequence_Check(result)) {
       printf("[CRITICAL] radio_getReceivedFrame() did not return a tuple\r\n");
@@ -300,9 +304,9 @@ void radio_getReceivedFrame(OpenMote* self,
       printf("[CRITICAL] radio_getReceivedFrame() did not return a tuple of exactly 4 elements %d\r\n",PyList_Size(result));
       return;
    }
-   
+
    //==== item 0: rxBuffer
-   
+
    item       = PyTuple_GetItem(result,0);
    lenRead    = PyList_Size(item);
    *pLenRead  = lenRead;
@@ -311,19 +315,19 @@ void radio_getReceivedFrame(OpenMote* self,
       subitem = PyList_GetItem(item, i);
       pBufRead[i] = (uint8_t)PyInt_AsLong(subitem);
    }
-   
+
    //==== item 1: rssi
-   
+
    item       = PyTuple_GetItem(result,1);
    *pRssi     = (int8_t)PyInt_AsLong(item);
-   
+
    //==== item 2: lqi
-   
+
    item       = PyTuple_GetItem(result,2);
    *pLqi      = (uint8_t)PyInt_AsLong(item);
-   
+
    //==== item 3: crc
-   
+
    item       = PyTuple_GetItem(result,3);
    *pCrc      = (uint8_t)PyInt_AsLong(item);
 }

--- a/bsp/boards/radio.h
+++ b/bsp/boards/radio.h
@@ -22,7 +22,7 @@
 \brief Current state of the radio.
 
 \note This radio driver is very minimal in that it does not follow a state machine.
-      It is up to the MAC layer to ensure that the different radio operations 
+      It is up to the MAC layer to ensure that the different radio operations
       are called in the righr order. The radio keeps a state for debugging purposes only.
 */
 typedef enum {
@@ -42,6 +42,17 @@ typedef enum {
    RADIOSTATE_TURNING_OFF         = 0x0d,   ///< Turning the RF chain off.
 } radio_state_t;
 
+/**
+\brief Helper structure for power configuration to be defined by platforms with specific values.
+
+\note Not all values are supported by all platforms. In case the value is not supported, the closest higher
+value SHOULD be configured by the implementation in radio_setTxPower() function.
+*/
+typedef struct {
+   int8_t  power_dbm;
+   uint8_t register_val;
+} radio_output_power_config_t;
+
 //=========================== typedef =========================================
 
 typedef void  (*radio_capture_cbt)(PORT_TIMER_WIDTH timestamp);
@@ -58,6 +69,7 @@ void                radio_setEndFrameCb(radio_capture_cbt cb);
 void                radio_reset(void);
 // RF admin
 void                radio_setFrequency(uint8_t frequency);
+void                radio_setTxPower(int8_t power);  // Transmit power configuration in dBm
 void                radio_rfOn(void);
 void                radio_rfOff(void);
 // TX

--- a/bsp/boards/silabs-ezr32wg/radio.c
+++ b/bsp/boards/silabs-ezr32wg/radio.c
@@ -117,6 +117,10 @@ void radio_setFrequency(uint8_t frequency) {
 	radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
+void radio_setTxPower(int8_t power) {
+    // TODO
+}
+
 void radio_rfOn(void) {
 
 }

--- a/bsp/chips/at86rf215/radio.c
+++ b/bsp/chips/at86rf215/radio.c
@@ -206,6 +206,10 @@ void radio_setFrequency(uint16_t channel) {
     radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
+void radio_setTxPower(int8_t power) {
+    // TODO
+}
+
 void radio_rfOn(void) {
     //put the radio in the TRXPREP state
     at86rf215_spiStrobe(CMD_RF_TRXOFF, ATMEL_FREQUENCY_TYPE);

--- a/bsp/chips/at86rf233/radio.c
+++ b/bsp/chips/at86rf233/radio.c
@@ -1,35 +1,35 @@
 /**
-* Copyright (c) 2014 Atmel Corporation. All rights reserved. 
-*  
-* Redistribution and use in source and binary forms, with or without 
+* Copyright (c) 2014 Atmel Corporation. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
-* 
+*
 * 1. Redistributions of source code must retain the above copyright notice, this
 * list of conditions and the following disclaimer.
-* 
-* 2. Redistributions in binary form must reproduce the above copyright notice, 
-* this list of conditions and the following disclaimer in the documentation 
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
 * and/or other materials provided with the distribution.
-* 
-* 3. The name of Atmel may not be used to endorse or promote products derived 
-* from this software without specific prior written permission.  
-* 
-* 4. This software may only be redistributed and used in connection with an 
+*
+* 3. The name of Atmel may not be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* 4. This software may only be redistributed and used in connection with an
 * Atmel microcontroller product.
-* 
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-* GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
-* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
-* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+* GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
-* 
-* 
+*
+*
+*
 */
 
 #include "board.h"
@@ -47,7 +47,7 @@
 typedef struct {
    radiotimer_capture_cbt    startFrame_cb;
    radiotimer_capture_cbt    endFrame_cb;
-   radio_state_t             state; 
+   radio_state_t             state;
 } radio_vars_t;
 
 radio_vars_t radio_vars;
@@ -72,25 +72,25 @@ void radio_init(void) {
    // clear variables
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_STOPPED;
-  
+
   //Check the radio part number. If the H/W interface in not initialized it statys here */
   while (trx_reg_read(RG_PART_NUM) != AT86RF233_PART_NUM);
-  
+
    // configure the radio
    radio_spiWriteReg(RG_TRX_STATE, CMD_FORCE_TRX_OFF);    // turn radio off
-  
+
    radio_spiWriteReg(RG_IRQ_MASK,
                      (AT_IRQ_RX_START| AT_IRQ_TRX_END));  // tell radio to fire interrupt on TRX_END and RX_START
    radio_spiReadReg(RG_IRQ_STATUS);                       // deassert the interrupt pin in case is high
    radio_spiWriteReg(RG_ANT_DIV, RADIO_CHIP_ANTENNA);     // use chip antenna
    radio_spiWriteReg(RG_TRX_CTRL_1, 0x20);                // have the radio calculate CRC
    //busy wait until radio status is TRX_OFF
-  
+
    while((radio_spiReadReg(RG_TRX_STATUS) & 0x1F) != TRX_OFF);
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_RFOFF;
 }
@@ -140,12 +140,16 @@ PORT_TIMER_WIDTH radio_getTimerPeriod(void) {
 void radio_setFrequency(uint8_t frequency) {
    // change state
    radio_vars.state = RADIOSTATE_SETTING_FREQUENCY;
-   
+
    // configure the radio to the right frequency
    radio_spiWriteReg(RG_PHY_CC_CCA,0x20+frequency);
-   
+
    // change state
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
+}
+
+void radio_setTxPower(int8_t power) {
+    // TODO
 }
 
 void radio_rfOn(void) {
@@ -160,11 +164,11 @@ void radio_rfOff(void) {
    radio_spiWriteReg(RG_TRX_STATE, CMD_FORCE_TRX_OFF);
    //radio_spiWriteReg(RG_TRX_STATE, CMD_TRX_OFF);
    while((radio_spiReadReg(RG_TRX_STATUS) & 0x1F) != TRX_OFF); // busy wait until done
-   
+
    // wiggle debug pin
    debugpins_radio_clr();
    leds_radio_off();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_RFOFF;
 }
@@ -174,10 +178,10 @@ void radio_rfOff(void) {
 void radio_loadPacket(uint8_t* packet, uint16_t len) {
    // change state
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
-   
+
    // load packet in TXFIFO
    radio_spiWriteTxFifo(packet,len);
-   
+
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
@@ -185,15 +189,15 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
 void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
-   
+
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    // turn on radio's PLL
    radio_spiWriteReg(RG_TRX_STATE, CMD_PLL_ON);
    while((radio_spiReadReg(RG_TRX_STATUS) & 0x1F) != PLL_ON); // busy wait until done
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
@@ -202,11 +206,11 @@ void radio_txNow(void) {
    PORT_TIMER_WIDTH val;
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
-   
+
    // send packet by pulsing the SLP_TR_CNTL pin
    PORT_PIN_RADIO_SLP_TR_CNTL_HIGH();
    PORT_PIN_RADIO_SLP_TR_CNTL_LOW();
-   
+
    // The AT86RF231 does not generate an interrupt when the radio transmits the
    // SFD, which messes up the MAC state machine. The danger is that, if we leave
    // this funtion like this, any radio watchdog timer will expire.
@@ -226,17 +230,17 @@ void radio_txNow(void) {
 void radio_rxEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
-   
+
    // put radio in reception mode
    radio_spiWriteReg(RG_TRX_STATE, CMD_RX_ON);
-   
+
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    // busy wait until radio really listening
    while((radio_spiReadReg(RG_TRX_STATUS) & 0x1F) != RX_ON);
-   
+
    // change state
    radio_vars.state = RADIOSTATE_LISTENING;
 }
@@ -252,17 +256,17 @@ void radio_getReceivedFrame(uint8_t* pBufRead,
                             uint8_t* pLqi,
                             uint8_t* pCrc) {
    uint8_t temp_reg_value;
-   
+
    //===== crc
    temp_reg_value  = radio_spiReadReg(RG_PHY_RSSI);
    *pCrc           = (temp_reg_value & 0x80)>>7;  // msb is whether packet passed CRC
-   
+
    //===== rssi
    // as per section 8.5.3 of the AT86RF233, the RSSI is calculate as:
    // -91 + ED [dBm]
    temp_reg_value  = radio_spiReadReg(RG_PHY_ED_LEVEL);
    *pRssi          = -91 + temp_reg_value;
-   
+
    //===== packet
    radio_spiReadRxFifo(pBufRead,
                        pLenRead,
@@ -299,10 +303,10 @@ uint8_t radio_spiReadRadioInfo(void) {
 void radio_spiWriteReg(uint8_t reg_addr, uint8_t reg_setting) {
    uint8_t spi_tx_buffer[2];
    uint8_t spi_rx_buffer[2];
-   
+
    spi_tx_buffer[0] = (0xC0 | reg_addr);        // turn address in a 'reg write' address
    spi_tx_buffer[1] = reg_setting;
-   
+
    spi_txrx(spi_tx_buffer,
             sizeof(spi_tx_buffer),
             SPI_BUFFER,
@@ -315,10 +319,10 @@ void radio_spiWriteReg(uint8_t reg_addr, uint8_t reg_setting) {
 uint8_t radio_spiReadReg(uint8_t reg_addr) {
    uint8_t spi_tx_buffer[2];
    uint8_t spi_rx_buffer[2];
-   
+
    spi_tx_buffer[0] = (0x80 | reg_addr);        // turn addess in a 'reg read' address
    spi_tx_buffer[1] = 0x00;                     // send a no_operation command just to get the reg value
-   
+
    spi_txrx(spi_tx_buffer,
             sizeof(spi_tx_buffer),
             SPI_BUFFER,
@@ -326,7 +330,7 @@ uint8_t radio_spiReadReg(uint8_t reg_addr) {
             sizeof(spi_rx_buffer),
             SPI_FIRST,
             SPI_LAST);
-   
+
 
   return spi_rx_buffer[1];
 }
@@ -336,10 +340,10 @@ uint8_t radio_spiReadReg(uint8_t reg_addr) {
 void radio_spiWriteTxFifo(uint8_t* bufToWrite, uint8_t  lenToWrite) {
    uint8_t spi_tx_buffer[2];
    uint8_t spi_rx_buffer[1+1+127];               // 1B SPI address, 1B length, max. 127B data
-   
+
    spi_tx_buffer[0] = 0x60;                      // SPI destination address for TXFIFO
    spi_tx_buffer[1] = lenToWrite;                // length byte
-   
+
    spi_txrx(spi_tx_buffer,
             sizeof(spi_tx_buffer),
             SPI_BUFFER,
@@ -347,7 +351,7 @@ void radio_spiWriteTxFifo(uint8_t* bufToWrite, uint8_t  lenToWrite) {
             sizeof(spi_rx_buffer),
             SPI_FIRST,
             SPI_NOTLAST);
-   
+
    spi_txrx(bufToWrite,
             lenToWrite,
             SPI_BUFFER,
@@ -371,9 +375,9 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
    // - *[1B]     LQI
    uint8_t spi_tx_buffer[125];
    uint8_t spi_rx_buffer[3];
-   
+
    spi_tx_buffer[0] = 0x20;
-   
+
    // 2 first bytes
    spi_txrx(spi_tx_buffer,
             2,
@@ -382,12 +386,12 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
             sizeof(spi_rx_buffer),
             SPI_FIRST,
             SPI_NOTLAST);
-   
+
    *pLenRead  = spi_rx_buffer[1];
-   
+
    if (*pLenRead>2 && *pLenRead<=127) {
       // valid length
-      
+
       //read packet
       spi_txrx(spi_tx_buffer,
                *pLenRead,
@@ -396,7 +400,7 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
                125,
                SPI_NOTFIRST,
                SPI_NOTLAST);
-      
+
       // CRC (2B) and LQI (1B)
       spi_txrx(spi_tx_buffer,
                2+1,
@@ -405,12 +409,12 @@ void radio_spiReadRxFifo(uint8_t* pBufRead,
                3,
                SPI_NOTFIRST,
                SPI_LAST);
-      
+
       *pLqi   = spi_rx_buffer[2];
-      
+
    } else {
       // invalid length
-      
+
       // read a just byte to close spi
       spi_txrx(spi_tx_buffer,
                1,
@@ -435,7 +439,7 @@ kick_scheduler_t radio_isr(void) {
 
    // reading IRQ_STATUS causes radio's IRQ pin to go low
    irq_status = radio_spiReadReg(RG_IRQ_STATUS);
-    
+
    // start of frame event
    if (irq_status & AT_IRQ_RX_START) {
       // change state
@@ -462,6 +466,6 @@ kick_scheduler_t radio_isr(void) {
          while(1);
       }
    }
-   
+
    return DO_NOT_KICK_SCHEDULER;
 }

--- a/bsp/chips/cc2420/radio.c
+++ b/bsp/chips/cc2420/radio.c
@@ -23,6 +23,18 @@ typedef struct {
 
 radio_vars_t radio_vars;
 
+/* TX Power dBm lookup table. Values from CC2420 datasheet */
+static const radio_output_power_config_t cc2420_output_power[] = {
+   {   0, 31 },
+   {  -1, 27 },
+   {  -3, 23 },
+   {  -5, 19 },
+   {  -7, 15 },
+   { -10, 11 },
+   { -15, 7  },
+   { -25, 3  },
+};
+
 //=========================== public ==========================================
 
 //===== admin
@@ -30,16 +42,16 @@ radio_vars_t radio_vars;
 void radio_init(void) {
    // clear variables
    memset(&radio_vars,0,sizeof(radio_vars_t));
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_STOPPED;
-   
+
    // reset radio
    radio_reset();
-   
+
    // change state
    radio_vars.state          = RADIOSTATE_RFOFF;
-   
+
 }
 
 void radio_setStartFrameCb(radio_capture_cbt cb) {
@@ -57,19 +69,19 @@ void radio_reset(void) {
    cc2420_MDMCTRL0_reg_t cc2420_MDMCTRL0_reg;
    cc2420_TXCTRL_reg_t   cc2420_TXCTRL_reg;
    cc2420_RXCTRL1_reg_t  cc2420_RXCTRL1_reg;
-   
+
    // set radio VREG pin high
    PORT_PIN_RADIO_VREG_HIGH();
    for (delay=0xffff;delay>0;delay--);           // max. VREG start-up time is 0.6ms
-   
+
    // set radio RESET pin low
    PORT_PIN_RADIO_RESET_LOW();
    for (delay=0xffff;delay>0;delay--);
-   
+
    // set radio RESET pin high
    PORT_PIN_RADIO_RESET_HIGH();
    for (delay=0xffff;delay>0;delay--);
-   
+
    // disable address recognition
    cc2420_MDMCTRL0_reg.PREAMBLE_LENGTH      = 2; // 3 leading zero's (IEEE802.15.4 compliant)
    cc2420_MDMCTRL0_reg.AUTOACK              = 0;
@@ -85,7 +97,7 @@ void radio_reset(void) {
       &radio_vars.radioStatusByte,
       *(uint16_t*)&cc2420_MDMCTRL0_reg
    );
-   
+
    // speed up time to TX
    cc2420_TXCTRL_reg.PA_LEVEL               = 31;// max. TX power (~0dBm)
    cc2420_TXCTRL_reg.reserved_w1            = 1;
@@ -99,7 +111,7 @@ void radio_reset(void) {
       &radio_vars.radioStatusByte,
       *(uint16_t*)&cc2420_TXCTRL_reg
    );
-   
+
    // apply correction recommended in datasheet
    cc2420_RXCTRL1_reg.RXMIX_CURRENT         = 2;
    cc2420_RXCTRL1_reg.RXMIX_VCM             = 1;
@@ -123,10 +135,10 @@ void radio_reset(void) {
 
 void radio_setFrequency(uint8_t frequency) {
    cc2420_FSCTRL_reg_t cc2420_FSCTRL_reg;
-   
+
    // change state
    radio_vars.state = RADIOSTATE_SETTING_FREQUENCY;
-   
+
    cc2420_FSCTRL_reg.FREQ         = frequency-11;
    cc2420_FSCTRL_reg.FREQ        *= 5;
    cc2420_FSCTRL_reg.FREQ        += 357;
@@ -135,18 +147,49 @@ void radio_setFrequency(uint8_t frequency) {
    cc2420_FSCTRL_reg.CAL_RUNNING  = 0;
    cc2420_FSCTRL_reg.CAL_DONE     = 0;
    cc2420_FSCTRL_reg.LOCK_THR     = 1;
-   
+
    cc2420_spiWriteReg(
       CC2420_FSCTRL_ADDR,
       &radio_vars.radioStatusByte,
       *(uint16_t*)&cc2420_FSCTRL_reg
    );
-   
+
    // change state
    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
 }
 
-void radio_rfOn(void) {   
+// configure the radio to output at least @power dBm, or the maximum available power
+void radio_setTxPower(int8_t power) {
+   cc2420_TXCTRL_reg_t   cc2420_TXCTRL_reg;
+   uint8_t               i;
+   uint8_t               reg_val;
+
+   // loop to find at-least :power: dBm in the look-up table
+   // if the max output power of a chip is higher than :power:, we configure the maximum
+   reg_val = cc2420_output_power[0].register_val;
+   for(i = sizeof(cc2420_output_power) / sizeof(radio_output_power_config_t) - 1; i >= 0; --i) {
+     if(power <= cc2420_output_power[i].power_dbm) {
+       reg_val = cc2420_output_power[i].register_val;
+       break;
+     }
+   }
+
+   // speed up time to TX
+   cc2420_TXCTRL_reg.PA_LEVEL               = reg_val;
+   cc2420_TXCTRL_reg.reserved_w1            = 1;
+   cc2420_TXCTRL_reg.PA_CURRENT             = 3;
+   cc2420_TXCTRL_reg.TXMIX_CURRENT          = 0;
+   cc2420_TXCTRL_reg.TXMIX_CAP_ARRAY        = 0;
+   cc2420_TXCTRL_reg.TX_TURNAROUND          = 0; // faster STXON->SFD timing (128us)
+   cc2420_TXCTRL_reg.TXMIXBUF_CUR           = 2;
+   cc2420_spiWriteReg(
+      CC2420_TXCTRL_ADDR,
+      &radio_vars.radioStatusByte,
+      *(uint16_t*)&cc2420_TXCTRL_reg
+   );
+}
+
+void radio_rfOn(void) {
    cc2420_spiStrobe(CC2420_SXOSCON, &radio_vars.radioStatusByte);
    while (radio_vars.radioStatusByte.xosc16m_stable==0) {
       cc2420_spiStrobe(CC2420_SNOP, &radio_vars.radioStatusByte);
@@ -154,17 +197,17 @@ void radio_rfOn(void) {
 }
 
 void radio_rfOff(void) {
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TURNING_OFF;
-   
+
    cc2420_spiStrobe(CC2420_SRFOFF, &radio_vars.radioStatusByte);
    // poipoipoi wait until off
-   
+
    // wiggle debug pin
    debugpins_radio_clr();
    leds_radio_off();
-   
+
    // change state
    radio_vars.state = RADIOSTATE_RFOFF;
 }
@@ -174,10 +217,10 @@ void radio_rfOff(void) {
 void radio_loadPacket(uint8_t* packet, uint16_t len) {
    // change state
    radio_vars.state = RADIOSTATE_LOADING_PACKET;
-   
+
    cc2420_spiStrobe(CC2420_SFLUSHTX, &radio_vars.radioStatusByte);
    cc2420_spiWriteFifo(&radio_vars.radioStatusByte, packet, len, CC2420_TXFIFO_ADDR);
-   
+
    // change state
    radio_vars.state = RADIOSTATE_PACKET_LOADED;
 }
@@ -185,13 +228,13 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
 void radio_txEnable(void) {
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
-   
+
    // wiggle debug pin
    debugpins_radio_set();
    leds_radio_on();
-   
+
    // I don't fully understand how the CC2420_STXCA the can be used here.
-   
+
    // change state
    radio_vars.state = RADIOSTATE_TX_ENABLED;
 }
@@ -199,7 +242,7 @@ void radio_txEnable(void) {
 void radio_txNow(void) {
    // change state
    radio_vars.state = RADIOSTATE_TRANSMITTING;
-   
+
    cc2420_spiStrobe(CC2420_STXON, &radio_vars.radioStatusByte);
 }
 
@@ -236,10 +279,10 @@ void radio_getReceivedFrame(
       uint8_t* lqi,
       bool*    crc
    ) {
-   
+
    // read the received packet from the RXFIFO
    cc2420_spiReadRxFifo(&radio_vars.radioStatusByte, bufRead, lenRead, maxBufLen);
-   
+
    // On reception, when MODEMCTRL0.AUTOCRC is set, the CC2420 replaces the
    // received CRC by:
    // - [1B] the rssi, a signed value. The actual value in dBm is that - 45.

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -343,6 +343,7 @@ functionsToChange = [
     'radio_setTimerPeriod',
     'radio_getTimerPeriod',
     'radio_setFrequency',
+    'radio_setTxPower',
     'radio_rfOn',
     'radio_rfOff',
     'radio_loadPacket',


### PR DESCRIPTION
This PR extends the `radio.h` API in order to provide support for configuring TX power. This is a necessary extension in order to enable an external agent, e.g. OpenVisualizer through CLI or OpenBenchmark platform, to configure the TX power of a given mote.

New `radio_setTxPower` API is implemented for CC2420, AT86RF231, and CC2538 -based boards. Mock up functions are added for other radio chips that are not supported at the moment.

The PR also removes the trailing whitespaces in all touched files.