### PR TITLE
FW-817. no free buffer error occurs on a node with 5 6P packets in queue

### DIFF
--- a/openstack/02b-MAChigh/msf.c
+++ b/openstack/02b-MAChigh/msf.c
@@ -82,10 +82,10 @@ void    msf_updateCellsPassed(open_addr_t* neighbor){
     msf_vars.numCellsPassed++;
     if (msf_vars.numCellsPassed == MAX_NUMCELLS){
         if (msf_vars.numCellsUsed > LIM_NUMCELLSUSED_HIGH){
-            msf_trigger6pAdd();
+            scheduler_push_task(msf_trigger6pAdd,TASKPRIO_MSF);
         }
         if (msf_vars.numCellsUsed < LIM_NUMCELLSUSED_LOW){
-            msf_trigger6pDelete();
+            scheduler_push_task(msf_trigger6pDelete,TASKPRIO_MSF);
         }
         msf_vars.numCellsPassed = 0;
         msf_vars.numCellsUsed   = 0;

--- a/openstack/02b-MAChigh/neighbors.c
+++ b/openstack/02b-MAChigh/neighbors.c
@@ -425,6 +425,10 @@ void neighbors_indicateTx(
         if (isThisRowMatching(l2_dest,i)) {
             // found the target neighbor
 
+            // reset backoff variable
+            neighbors_vars.neighbors[i].backoffExponenton     = MINBE-1;
+            neighbors_vars.neighbors[i].backoff               = 0;
+
             // update asn if ack'ed
             if (was_finally_acked==TRUE) {
                 memcpy(&neighbors_vars.neighbors[i].asn,asnTs,sizeof(asn_t));

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -1491,7 +1491,6 @@ void sixtop_six2six_notifyReceive(
 
     if (type == SIXTOP_CELL_RESPONSE) {
         // this is a 6p response message
-        neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
 
         // if the code is SUCCESS
         if (code == IANA_6TOP_RC_SUCCESS || code == IANA_6TOP_RC_EOL){
@@ -1515,6 +1514,7 @@ void sixtop_six2six_notifyReceive(
                     &(pkt->l2_nextORpreviousHop), // neighbor that cells to be added to
                     sixtop_vars.cellOptions       // cell options
                 );
+                neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             case SIX_STATE_WAIT_DELETERESPONSE:
                 sixtop_removeCells(
@@ -1523,6 +1523,7 @@ void sixtop_six2six_notifyReceive(
                     &(pkt->l2_nextORpreviousHop),
                     sixtop_vars.cellOptions
                 );
+                neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             case SIX_STATE_WAIT_RELOCATERESPONSE:
                 i = 0;
@@ -1549,6 +1550,7 @@ void sixtop_six2six_notifyReceive(
                     &(pkt->l2_nextORpreviousHop), // neighbor that cells to be added to
                     sixtop_vars.cellOptions       // cell options
                 );
+                neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             case SIX_STATE_WAIT_COUNTRESPONSE:
                 numCells  = *((uint8_t*)(pkt->payload)+ptr);
@@ -1560,6 +1562,7 @@ void sixtop_six2six_notifyReceive(
                     (errorparameter_t)numCells,
                     (errorparameter_t)sixtop_vars.six2six_state
                 );
+                neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             case SIX_STATE_WAIT_LISTRESPONSE:
                 i = 0;
@@ -1581,6 +1584,7 @@ void sixtop_six2six_notifyReceive(
                     (errorparameter_t)celllist_list[0].slotoffset,
                     (errorparameter_t)celllist_list[1].slotoffset
                 );
+                neighbors_updateSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             case SIX_STATE_WAIT_CLEARRESPONSE:
                 schedule_removeAllManagedUnicastCellsToNeighbor(
@@ -1590,7 +1594,13 @@ void sixtop_six2six_notifyReceive(
                 neighbors_resetSequenceNumber(&(pkt->l2_nextORpreviousHop));
                 break;
             default:
-                // should neven happen
+                // The sixtop response arrived after 6P TIMEOUT.
+
+
+                // it's a duplicated response.
+
+                openqueue_remove6PrequestToNeighbor(&(pkt->l2_nextORpreviousHop));
+
                 break;
             }
         } else {

--- a/openstack/cross-layers/openqueue.c
+++ b/openstack/cross-layers/openqueue.c
@@ -192,8 +192,8 @@ uint8_t openqueue_getNum6PResp(void){
     num6Presponse = 0;
     for (i=0;i<QUEUELENGTH;i++) {
         if (
-            openqueue_vars.queue[i].owner == COMPONENT_IEEE802154E_TO_SIXTOP  &&
-            openqueue_vars.queue[i].creator == COMPONENT_SIXTOP_RES           &&
+            openqueue_vars.queue[i].owner   == COMPONENT_IEEE802154E_TO_SIXTOP  &&
+            openqueue_vars.queue[i].creator == COMPONENT_SIXTOP_RES             &&
             openqueue_vars.queue[i].l2_sixtop_messageType == SIXTOP_CELL_RESPONSE
         ) {
             num6Presponse += 1;
@@ -201,6 +201,26 @@ uint8_t openqueue_getNum6PResp(void){
     }
     ENABLE_INTERRUPTS();
     return num6Presponse;
+}
+
+void openqueue_remove6PrequestToNeighbor(open_addr_t* neighbor){
+
+    uint8_t i;
+
+    INTERRUPT_DECLARATION();
+    DISABLE_INTERRUPTS();
+
+    for (i=0;i<QUEUELENGTH;i++) {
+        if (
+            openqueue_vars.queue[i].owner   == COMPONENT_IEEE802154E_TO_SIXTOP   &&
+            openqueue_vars.queue[i].creator == COMPONENT_SIXTOP_RES              &&
+            openqueue_vars.queue[i].l2_sixtop_messageType == SIXTOP_CELL_REQUEST &&
+            packetfunctions_sameAddress(neighbor,&openqueue_vars.queue[i].l2_nextORpreviousHop)
+        ) {
+            openqueue_reset_entry(&(openqueue_vars.queue[i]));
+        }
+    }
+    ENABLE_INTERRUPTS();
 }
 
 //======= called by IEEE80215E

--- a/openstack/cross-layers/openqueue.h
+++ b/openstack/cross-layers/openqueue.h
@@ -44,6 +44,7 @@ void               openqueue_updateNextHopPayload(open_addr_t* newNextHop);
 OpenQueueEntry_t*  openqueue_sixtopGetSentPacket(void);
 OpenQueueEntry_t*  openqueue_sixtopGetReceivedPacket(void);
 uint8_t            openqueue_getNum6PResp(void);
+void               openqueue_remove6PrequestToNeighbor(open_addr_t* neighbor);
 // called by IEEE80215E
 OpenQueueEntry_t*  openqueue_macGet6PResponseAndDownStreamPacket(open_addr_t* toNeighbor);
 OpenQueueEntry_t*  openqueue_macGet6PRequestOnAnycast(open_addr_t* autonomousUnicastNeighbor);

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -834,6 +834,7 @@ functionsToChange = [
     'openqueue_macGet6PandJoinPacket',
     'openqueue_updateNextHopPayload',
     'openqueue_getNum6PResp',
+    'openqueue_remove6PrequestToNeighbor',
     # openrandom
     'openrandom_init',
     'openrandom_get16b',


### PR DESCRIPTION
- [x] reset neighbor backoff when packet sendDone
- [x] remove 6P request to neighbor when receiving a 6P response from that neighbor with a wrong state