### PR TITLE
Fix several compiler warnings

### DIFF
--- a/drivers/common/openserial.c
+++ b/drivers/common/openserial.c
@@ -278,6 +278,8 @@ owerror_t openserial_print_uint32_t(uint32_t value) {
 
     // start TX'ing
     openserial_flush();
+#else
+    (void)value;
 #endif
     return E_SUCCESS;
 }
@@ -305,6 +307,9 @@ owerror_t openserial_print_str(char* buffer, uint8_t length) {
 
     // start TX'ing
     openserial_flush();
+#else
+    (void)buffer;
+    (void)length;
 #endif
    return E_SUCCESS;
 }
@@ -335,50 +340,62 @@ void task_openserial_debugPrint(void) {
             if (debugPrint_isSync()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_ID:
             if (debugPrint_id()==TRUE) {
                break;
             }
+            /* fall through */
         case STATUS_DAGRANK:
             if (debugPrint_myDAGrank()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_OUTBUFFERINDEXES:
             if (debugPrint_outBufferIndexes()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_ASN:
             if (debugPrint_asn()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_MACSTATS:
             if (debugPrint_macStats()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_SCHEDULE:
             if(debugPrint_schedule()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_BACKOFF:
             if(debugPrint_backoff()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_QUEUE:
             if(debugPrint_queue()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_NEIGHBORS:
             if (debugPrint_neighbors()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_KAPERIOD:
             if (debugPrint_kaPeriod()==TRUE) {
                 break;
             }
+            /* fall through */
         case STATUS_JOINED:
             if (debugPrint_joined()==TRUE) {
                 break;
             }
+            /* fall through */
         default:
             debugPrintCounter=0;
     }
@@ -392,7 +409,7 @@ void task_openserial_debugPrint(void) {
 
 //===== receiving
 
-uint8_t openserial_getInputBufferFillLevel() {
+uint8_t openserial_getInputBufferFillLevel(void) {
     uint8_t inputBufFillLevel;
     INTERRUPT_DECLARATION();
 
@@ -576,7 +593,7 @@ owerror_t openserial_printInfoErrorCritical(
 //===== command handlers
 
 // executed in ISR
-void openserial_handleRxFrame() {
+void openserial_handleRxFrame(void) {
     uint8_t cmdByte;
 
     cmdByte = openserial_vars.inputBuf[0];
@@ -859,6 +876,7 @@ void openserial_handleCommands(void){
 //===== misc
 
 void openserial_debugPrint_timer_cb(opentimers_id_t id){
+    (void)id;
     // calling the task directly as the timer_cb function is executed in
     // task mode by opentimer already
     task_openserial_debugPrint();

--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -276,6 +276,7 @@ void ieee154e_orderToASNStructure(uint8_t* in,asn_t* val_asn) {
 This function executes in ISR mode, when the new slot timer fires.
 */
 void isr_ieee154e_newSlot(opentimers_id_t id) {
+    (void)id;
 
     ieee154e_vars.startOfSlotReference = opentimers_getCurrentCompareValue();
     opentimers_scheduleAbsolute(
@@ -311,6 +312,7 @@ void isr_ieee154e_newSlot(opentimers_id_t id) {
 This function executes in ISR mode, when the FSM timer fires.
 */
 void isr_ieee154e_timer(opentimers_id_t id) {
+    (void)id;
     switch (ieee154e_vars.state) {
         case S_TXDATAOFFSET:
             activity_ti2();
@@ -397,6 +399,7 @@ This needs to happen
 This function executes in ISR mode.
 */
 void isr_ieee154e_inhibitStart(opentimers_id_t id) {
+    (void)id;
     // inhibit serial activity
     openserial_inhibitStart(); // activity_inhibitSerial
 }
@@ -660,6 +663,8 @@ port_INLINE void activity_synchronize_startOfFrame(PORT_TIMER_WIDTH capturedTime
 }
 
 port_INLINE void activity_synchronize_endOfFrame(PORT_TIMER_WIDTH capturedTime) {
+   (void)capturedTime;
+
    ieee802154_header_iht ieee802514_header;
    uint16_t              lenIE;
 
@@ -1080,6 +1085,7 @@ port_INLINE void activity_ti1ORri1(void) {
 #endif
                 break;
             }
+            /* fall through */
         case CELLTYPE_RX:
             // change state
             changeState(S_RXDATAOFFSET);

--- a/openstack/02a-MAClow/IEEE802154_security.c
+++ b/openstack/02a-MAClow/IEEE802154_security.c
@@ -539,34 +539,46 @@ bool IEEE802154_security_acceptableLevel(OpenQueueEntry_t* msg, ieee802154_heade
 #else /* L2_SECURITY_ACTIVE */
 
 void IEEE802154_security_prependAuxiliarySecurityHeader(OpenQueueEntry_t* msg){
+    (void)msg;
     return;
 }
 
 void IEEE802154_security_retrieveAuxiliarySecurityHeader(OpenQueueEntry_t* msg, ieee802154_header_iht* tempheader) {
+    (void)msg;
+    (void)tempheader;
     return;
 }
 
 owerror_t IEEE802154_security_outgoingFrameSecurity(OpenQueueEntry_t* msg) {
+    (void)msg;
     return E_SUCCESS;
 }
 
 owerror_t IEEE802154_security_incomingFrame(OpenQueueEntry_t* msg) {
+    (void)msg;
     return E_SUCCESS;
 }
 
 uint8_t IEEE802154_security_authLengthChecking(uint8_t sec_level) {
+    (void)sec_level;
     return (uint8_t) 0;
 }
 
 uint8_t IEEE802154_security_auxLengthChecking(uint8_t kid, uint8_t sup, uint8_t size) {
+    (void)kid;
+    (void)sup;
+    (void)size;
     return (uint8_t) 0;
 }
 
 uint8_t IEEE802154_security_getSecurityLevel(OpenQueueEntry_t *msg) {
+    (void)msg;
     return IEEE154_ASH_SLF_TYPE_NOSEC;
 }
 
 bool IEEE802154_security_acceptableLevel(OpenQueueEntry_t* msg, ieee802154_header_iht* parsedheader) {
+    (void)msg;
+    (void)parsedheader;
     return TRUE;
 }
 

--- a/openstack/02a-MAClow/topology.c
+++ b/openstack/02a-MAClow/topology.c
@@ -97,6 +97,7 @@ bool topology_isAcceptablePacket(ieee802154_header_iht* ieee802514_header) {
    }
    return returnVal;
 #else
+   (void)ieee802514_header;
    return TRUE;
 #endif
 }

--- a/openstack/02b-MAChigh/msf.c
+++ b/openstack/02b-MAChigh/msf.c
@@ -90,6 +90,8 @@ void    msf_updateCellsPassed(open_addr_t* neighbor){
         msf_vars.numCellsPassed = 0;
         msf_vars.numCellsUsed   = 0;
     }
+#else
+    (void)neighbor;
 #endif
 }
 
@@ -174,10 +176,12 @@ void msf_handleRCError(uint8_t code, open_addr_t* address){
 }
 
 void msf_timer_waitretry_cb(opentimers_id_t id){
+    (void)id;
     msf_vars.waitretry = FALSE;
 }
 
 void msf_timer_housekeeping_cb(opentimers_id_t id){
+    (void)id;
     PORT_TIMER_WIDTH newDuration;
 
     // update the timer period
@@ -335,6 +339,7 @@ bool msf_candidateRemoveCellList(
       open_addr_t* neighbor,
       uint8_t      requiredCells
    ){
+    (void)neighbor;
     uint8_t              i;
     uint8_t              numCandCells;
     slotinfo_element_t   info;

--- a/openstack/02b-MAChigh/schedule.c
+++ b/openstack/02b-MAChigh/schedule.c
@@ -467,6 +467,7 @@ void schedule_removeAllManagedUnicastCellsToNeighbor(
     uint8_t        slotframeID,
     open_addr_t*   neighbor
     ){
+    (void)slotframeID;
     uint8_t i;
 
     // remove all entries in schedule with previousHop address
@@ -505,7 +506,7 @@ void schedule_removeAllAutonomousTxRxCellUnicast(void){
     msf_setHashCollisionFlag(FALSE);
 }
 
-uint8_t schedule_getNumberOfFreeEntries(){
+uint8_t schedule_getNumberOfFreeEntries(void){
     uint8_t i;
     uint8_t counter;
 
@@ -998,6 +999,9 @@ void schedule_indicateTx(asn_t* asnTimestamp, bool succesfullTx) {
 }
 
 bool schedule_getOneCellAfterOffset(uint8_t metadata,uint8_t offset,open_addr_t* neighbor, uint8_t cellOptions, uint16_t* slotoffset, uint16_t* channeloffset){
+    (void)metadata;
+    (void)neighbor;
+
     bool returnVal;
     scheduleEntry_t* scheduleWalker;
     cellType_t type;

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -653,7 +653,7 @@ owerror_t sixtop_send_internal(
     already. No need to push a task again.
 */
 void sixtop_sendingEb_timer_cb(opentimers_id_t id){
-
+    (void)id;
     timer_sixtop_sendEb_fired();
 }
 
@@ -664,6 +664,7 @@ void sixtop_sendingEb_timer_cb(opentimers_id_t id){
     already. No need to push a task again.
 */
 void sixtop_maintenance_timer_cb(opentimers_id_t id) {
+    (void)id;
     timer_sixtop_management_fired();
 }
 
@@ -674,6 +675,7 @@ void sixtop_maintenance_timer_cb(opentimers_id_t id) {
     already. No need to push a task again.
 */
 void sixtop_timeout_timer_cb(opentimers_id_t id) {
+    (void)id;
     timer_sixtop_six2six_timeout_fired();
 }
 
@@ -1631,6 +1633,7 @@ bool sixtop_addCells(
     open_addr_t* previousHop,
     uint8_t      cellOptions
 ){
+    (void)slotframeID;
     uint8_t     i;
     bool        isShared;
     open_addr_t temp_neighbor;
@@ -1677,6 +1680,8 @@ bool sixtop_removeCells(
       open_addr_t* previousHop,
     uint8_t      cellOptions
    ){
+    (void)slotframeID;
+    (void)cellOptions;
     uint8_t     i;
     open_addr_t temp_neighbor;
     bool        hasCellsRemoved;
@@ -1703,6 +1708,7 @@ bool sixtop_areAvailableCellsToBeScheduled(
       uint8_t      numOfCells,
       cellInfo_ht* cellList
 ){
+    (void)frameID;
     uint8_t i;
     uint8_t numbOfavailableCells;
     bool    available;
@@ -1749,6 +1755,8 @@ bool sixtop_areAvailableCellsToBeRemoved(
     open_addr_t* neighbor,
     uint8_t      cellOptions
 ){
+    (void)frameID;
+    (void)neighbor;
     uint8_t              i;
     uint8_t              numOfavailableCells;
     bool                 available;

--- a/openstack/03a-IPHC/iphc.c
+++ b/openstack/03a-IPHC/iphc.c
@@ -79,6 +79,9 @@ owerror_t iphc_sendFromForwarding(
     uint8_t           rh3_length,
     uint8_t           fw_SendOrfw_Rcv
     ) {
+    (void)flow_label;
+    (void)fw_SendOrfw_Rcv;
+
     open_addr_t  temp_dest_prefix;
     open_addr_t  temp_dest_mac64b; 
     open_addr_t  temp_src_prefix;
@@ -1096,6 +1099,8 @@ void iphc_prependIPv6HopByHopHeader(
       uint8_t           nextheader,
       rpl_option_ht*    rpl_option
    ){
+   (void)nextheader;
+
    uint8_t temp_8b;
    
    if ((rpl_option->flags & K_FLAG) == 0){

--- a/openstack/03a-IPHC/openbridge.c
+++ b/openstack/03a-IPHC/openbridge.c
@@ -69,6 +69,7 @@ void openbridge_triggerData(void) {
 }
 
 void openbridge_sendDone(OpenQueueEntry_t* msg, owerror_t error) {
+  (void)error;
    msg->owner = COMPONENT_OPENBRIDGE;
    if (msg->creator!=COMPONENT_OPENBRIDGE) {
       openserial_printError(COMPONENT_OPENBRIDGE,ERR_UNEXPECTED_SENDDONE,

--- a/openstack/03b-IPv6/icmpv6echo.c
+++ b/openstack/03b-IPv6/icmpv6echo.c
@@ -82,6 +82,8 @@ void icmpv6echo_trigger(void) {
 }
 
 void icmpv6echo_sendDone(OpenQueueEntry_t* msg, owerror_t error) {
+   (void)error;
+
    msg->owner = COMPONENT_ICMPv6ECHO;
    if (msg->creator!=COMPONENT_ICMPv6ECHO) {//that was a packet I had not created
       openserial_printError(COMPONENT_ICMPv6ECHO,ERR_UNEXPECTED_SENDDONE,

--- a/openstack/03b-IPv6/icmpv6rpl.c
+++ b/openstack/03b-IPv6/icmpv6rpl.c
@@ -224,7 +224,7 @@ owerror_t icmpv6rpl_getRPLDODAGid(uint8_t* address_128b){
 \param[in] error Outcome of the sending.
 */
 void icmpv6rpl_sendDone(OpenQueueEntry_t* msg, owerror_t error) {
-
+   (void)error;
    // take ownership over that packet
    msg->owner = COMPONENT_ICMPv6RPL;
 
@@ -659,6 +659,7 @@ void icmpv6rpl_killPreferredParent(void) {
     already. No need to push a task again.
 */
 void icmpv6rpl_timer_DIO_cb(opentimers_id_t id) {
+    (void)id;
     icmpv6rpl_timer_DIO_task();
 }
 
@@ -825,7 +826,7 @@ void sendDIO(void) {
     already. No need to push a task again.
 */
 void icmpv6rpl_timer_DAO_cb(opentimers_id_t id) {
-
+    (void)id;
     icmpv6rpl_timer_DAO_task();
 }
 

--- a/openstack/04-TRAN/openudp.c
+++ b/openstack/04-TRAN/openudp.c
@@ -240,6 +240,7 @@ bool openudp_debugPrint(void) {
 //=========================== private =========================================
 
 static void openudp_sendDone_default_handler(OpenQueueEntry_t* msg, owerror_t error) {
+   (void)error;
    openqueue_freePacketBuffer(msg);
 }
 

--- a/openstack/cross-layers/openqueue.c
+++ b/openstack/cross-layers/openqueue.c
@@ -377,7 +377,7 @@ OpenQueueEntry_t* openqueue_macGetKaPacket(open_addr_t* toNeighbor) {
     return NULL;
 }
 
-OpenQueueEntry_t*  openqueue_macGetDIOPacket(){
+OpenQueueEntry_t*  openqueue_macGetDIOPacket(void){
     uint8_t i;
     INTERRUPT_DECLARATION();
     DISABLE_INTERRUPTS();


### PR DESCRIPTION
This PR fixes several compiler warnings all over the code-base, many of which just appeared after switching to `arm-none-eabi-gcc 7.3.1`. Let me know of any required changes or simply close the PR if it's not of interest.