### PR TITLE
FW-842. Bugfix in 03oos_mercator.c

### DIFF
--- a/projects/common/03oos_mercator/03oos_mercator.c
+++ b/projects/common/03oos_mercator/03oos_mercator.c
@@ -467,6 +467,7 @@ void cb_endFrame(PORT_TIMER_WIDTH timestamp) {
    if (mercator_vars.status == ST_RX){
 
       // get packet from radio
+      memset(mercator_vars.rxpk_buf, 0, sizeof(mercator_vars.rxpk_buf));
       radio_getReceivedFrame(
          mercator_vars.rxpk_buf,
          &mercator_vars.rxpk_len,

--- a/projects/common/03oos_mercator/03oos_mercator.c
+++ b/projects/common/03oos_mercator/03oos_mercator.c
@@ -461,6 +461,7 @@ void cb_endFrame(PORT_TIMER_WIDTH timestamp) {
    RF_PACKET_ht* rx_temp;
    bool         is_expected = TRUE;
    IND_RX_ht*   resp;
+   int i;
 
    radio_rfOff();
 
@@ -496,7 +497,7 @@ void cb_endFrame(PORT_TIMER_WIDTH timestamp) {
       }
 
       // check txfillbyte
-      for (int i = offsetof(RF_PACKET_ht, txfillbyte);
+      for (i = offsetof(RF_PACKET_ht, txfillbyte);
            i < mercator_vars.rxpk_len - LENGTH_CRC; i++){
          if(mercator_vars.rxpk_buf[i] != mercator_vars.txpk_txfillbyte){
             is_expected = FALSE;


### PR DESCRIPTION
In addition to the fix, I moved a variable definition, which was in a `for` statement, to the beginning of the function for the sake of non-C99 compilers.