### PR TITLE
FW-841. Mercator: keep ST_TX status even after sending IND_TX

### DIFF
--- a/projects/common/03oos_mercator/03oos_mercator.c
+++ b/projects/common/03oos_mercator/03oos_mercator.c
@@ -550,10 +550,10 @@ void cb_sendPacket(opentimers_id_t id){
 
      mercator_vars.numnotifications++;
 
-     // goto IDLE
+     // turn off the radio just in case
      radio_rfOff();
-     mercator_vars.status = ST_IDLE;
-
+     // we keep the current status, ST_TX, which will be changed to
+     // ST_IDLE by the user
      return;
    }
 


### PR DESCRIPTION
This PR reverts a change, https://github.com/openwsn-berkeley/openwsn-fw/pull/476/commits/5ffe1c369c12fd169a34934939de879382387f3f,  in PR #476 because I see a benefit in keeping `ST_TX` status even after sending `IND_TX`.

