### PR TITLE
FW-703. Cryptoengine implementation for iot-lab M3 nodes.

### DIFF
--- a/bsp/boards/iot-lab_A8-M3/SConscript
+++ b/bsp/boards/iot-lab_A8-M3/SConscript
@@ -23,6 +23,12 @@ source   = \
     Glob('configure/*.s') + \
     Glob('library/src/*.c')
 
+localEnv.Append(
+        CPPPATH =  [
+            os.path.join('#','bsp','chips','at86rf231'),
+        ],
+)
+
 board  = localEnv.Object(source=source) + rf231
 
 Return('board')

--- a/bsp/boards/iot-lab_A8-M3/cryptoengine.c
+++ b/bsp/boards/iot-lab_A8-M3/cryptoengine.c
@@ -1,10 +1,24 @@
 /**
-\brief Dummy implementation of cryptoengine.
+\brief Implementation of cryptoengine based on AT86RF231's hardware accelerator.
 */
 
 #include <stdint.h>
 #include <string.h>
+#include "at86rf231.h"
 #include "cryptoengine.h"
+#include "spi.h"
+#include "radio.h"
+
+//=========================== prototypes ======================================
+owerror_t at86rf231_crypto_load_key(uint8_t key[16]);
+owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer);
+static owerror_t aes_cbc_mac(uint8_t* a, uint8_t len_a, uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
+static owerror_t aes_ctr_enc(uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]);
+owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]);
+static void inc_counter(uint8_t* counter);
+
+//=========================== public ==========================================
 
 owerror_t cryptoengine_aes_ccms_enc(uint8_t* a,
          uint8_t len_a,
@@ -14,7 +28,25 @@ owerror_t cryptoengine_aes_ccms_enc(uint8_t* a,
          uint8_t l,
          uint8_t key[16],
          uint8_t len_mac) {
-   
+   uint8_t mac[CBC_MAX_MAC_SIZE];
+
+   if ((len_mac > CBC_MAX_MAC_SIZE) || (l != 2)) {
+      return E_FAIL;
+   }
+
+   if (at86rf231_crypto_load_key(key) != E_SUCCESS) {
+        return E_FAIL;
+   }
+
+   if (aes_cbc_mac(a, len_a, m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+      if (aes_ctr_enc(m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+         memcpy(&m[*len_m], mac, len_mac);
+         *len_m += len_mac;
+
+         return E_SUCCESS;
+      }
+   }
+
    return E_FAIL;
 }
 
@@ -26,15 +58,464 @@ owerror_t cryptoengine_aes_ccms_dec(uint8_t* a,
          uint8_t l,
          uint8_t key[16],
          uint8_t len_mac) {
-   
+   uint8_t mac[CBC_MAX_MAC_SIZE];
+   uint8_t orig_mac[CBC_MAX_MAC_SIZE];
+
+   if ((len_mac > CBC_MAX_MAC_SIZE) || (l != 2)) {
+      return E_FAIL;
+   }
+
+   if (at86rf231_crypto_load_key(key) != E_SUCCESS) {
+        return E_FAIL;
+   }
+
+   *len_m -= len_mac;
+   memcpy(mac, &m[*len_m], len_mac);
+
+   if (aes_ctr_enc(m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+      if (aes_cbc_mac(a, len_a, m, *len_m, nonce, orig_mac, len_mac, l) == E_SUCCESS) {
+         if (memcmp(mac, orig_mac, len_mac) == 0) {
+            return E_SUCCESS;
+         }
+      }
+   }
+
    return E_FAIL;
 }
 
 owerror_t cryptoengine_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
-   return E_FAIL;
+    if (at86rf231_crypto_load_key(key) == E_SUCCESS) {
+        at86rf231_crypto_opt_ecb(buffer);
+        return E_SUCCESS;
+    }
+    return E_FAIL;
 }
 
 owerror_t cryptoengine_init(void) {
+    radio_rfOn();
+    return E_SUCCESS;
+}
+
+//=========================== private =========================================
+// Optimized ECB AES encryption that does not load the key beforehand
+owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer) {
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+
+    uint8_t aes_cmd;
+    uint8_t aes_status;
+
+    aes_cmd = 0x80; // AES start
+    aes_status = 0x00;
+
+    spi_tx_buffer[0] = 0x40; // SRAM write
+    spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+    spi_tx_buffer[2] = 0x00; // ECB encryption
+
+    spi_txrx(spi_tx_buffer,
+            sizeof(spi_tx_buffer),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_FIRST,
+            SPI_NOTLAST);
+
+    spi_txrx((uint8_t*)buffer,
+            16,
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_NOTLAST);
+
+    spi_txrx(&aes_cmd,
+            sizeof(aes_cmd),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_LAST);
+
+    // Prepare to read the AES status register
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATUS;
+
+    // Busy wait reading AES status register until it is done or an error occurs
+    do {
+        spi_txrx(spi_tx_buffer,
+                sizeof(spi_tx_buffer),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_FIRST,
+                SPI_LAST);
+        aes_status = spi_rx_buffer[2];
+    } while((aes_status & 0x01) == 0x00);
+
+    if ((aes_status & 0x80) == 0x01) {
+        // an error occured
+        return E_FAIL;
+    }
+
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATE_KEY;
+
+    // send the command to read the ciphertext
+    spi_txrx(spi_tx_buffer,
+                2,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                16,
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+    // read the actual ciphertext
+    spi_txrx(spi_tx_buffer,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)buffer,
+                16,
+                SPI_NOTFIRST,
+                SPI_LAST);
+
+    return E_SUCCESS;
+}
+
+
+owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+
+    spi_tx_buffer[0] = 0x40; // SRAM write
+    spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+    spi_tx_buffer[2] = 0x10; // key mode
+
+    spi_txrx(spi_tx_buffer,
+            sizeof(spi_tx_buffer),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_FIRST,
+            SPI_NOTLAST);
+
+    spi_txrx((uint8_t*)key,
+            16,
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_LAST);
+
+    return E_SUCCESS;
+}
+
+/**
+\brief Raw AES-CBC encryption omitting everything but the last block. Assumes key
+    is already loaded in the engine.
+\param[in,out] buffer Message to be encrypted. First and last block will be overwritten.
+\param[in] len Message length. Must be multiple of 16 octets.
+\param[in] iv Buffer containing the Initialization Vector (16 octets).
+
+\returns E_SUCCESS when the encryption was successful.
+*/
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
+    uint8_t  n;
+    uint8_t  k;
+    uint8_t  nb;
+    uint8_t* pbuf;
+    uint8_t* pxor;
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+    uint8_t aes_cmd;
+    uint8_t aes_status;
+
+    nb = len >> 4;
+    pxor = iv;
+    pbuf = buffer;
+    for (k = 0; k < 16; k++) {
+        pbuf[k] ^= pxor[k];
+    }
+    at86rf231_crypto_opt_ecb(pbuf);
+
+    aes_cmd = 0xA0; // AES-CBC encryption start
+    aes_status = 0x00;
+    // first block already done, start actual CBC processing in hardware
+    for (n = 1; n<nb; n++) {
+        pbuf = &buffer[16 * n];
+        spi_tx_buffer[0] = 0x40; // SRAM write
+        spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+        spi_tx_buffer[2] = 0x20; // CBC encryption
+
+        spi_txrx(spi_tx_buffer,
+                sizeof(spi_tx_buffer),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+        spi_txrx((uint8_t*)pbuf,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_NOTFIRST,
+                SPI_NOTLAST);
+
+        spi_txrx(&aes_cmd,
+                sizeof(aes_cmd),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_NOTFIRST,
+                SPI_LAST);
+
+        // Prepare to read the AES status register
+        spi_tx_buffer[0] = 0x00;
+        spi_tx_buffer[1] = RG_AES_STATUS;
+
+        // Busy wait reading AES status register until it is done or an error occurs
+        do {
+            spi_txrx(spi_tx_buffer,
+                    sizeof(spi_tx_buffer),
+                    SPI_BUFFER,
+                    (uint8_t*)spi_rx_buffer,
+                    sizeof(spi_rx_buffer),
+                    SPI_FIRST,
+                    SPI_LAST);
+            aes_status = spi_rx_buffer[2];
+        } while((aes_status & 0x01) == 0x00);
+
+        if ((aes_status & 0x80) == 0x01) {
+            // an error occured
+            return E_FAIL;
+        }
+    }
+
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATE_KEY;
+
+    // send the command to read the last block
+    spi_txrx(spi_tx_buffer,
+                2,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                16,
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+    // read the actual ciphertext
+    spi_txrx(spi_tx_buffer,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)pbuf,
+                16,
+                SPI_NOTFIRST,
+                SPI_LAST);
+
    return E_SUCCESS;
 }
+
+/**
+\brief CBC-MAC generation specific to CCM*. Assumes key is already loaded in the
+engine.
+\param[in] a Pointer to the authentication only data.
+\param[in] len_a Length of authentication only data.
+\param[in] m Pointer to the data that is both authenticated and encrypted.
+\param[in] len_m Length of data that is both authenticated and encrypted.
+\param[in] nonce Buffer containing nonce (13 octets).
+\param[out] mac Buffer where the value of the CBC-MAC tag will be written.
+\param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
+\param[in] l CCM parameter L that allows selection of different nonce length.
+
+\returns E_SUCCESS when the generation was successful, E_FAIL otherwise.
+*/
+static owerror_t aes_cbc_mac(uint8_t* a,
+         uint8_t len_a,
+         uint8_t* m,
+         uint8_t len_m,
+         uint8_t* nonce,
+         uint8_t* mac,
+         uint8_t len_mac,
+         uint8_t l) {
+
+   uint8_t  pad_len;
+   uint8_t  len;
+   uint8_t  cbc_mac_iv[16];
+   uint8_t  buffer[128+16+16]; // max buffer plus IV
+
+   // asserts here
+   if (!((len_mac == 0) || (len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
+      return E_FAIL;
+   }
+
+   if ((len_a > 127) || (len_m > 127) || ((len_a + len_m) > 127)) {
+      return E_FAIL;
+   }
+
+   if (mac == 0) {
+      return E_FAIL;
+   }
+
+   memset(cbc_mac_iv, 0x00, 16); // CBC-MAC Initialization Vector is a zero string
+
+   // IV: flags (1B) | SADDR (8B) | ASN (5B) | len(m) (2B)
+   // X0 xor IV in first 16 bytes of buffer: set buffer[:16] as IV)
+   buffer[0] = 0x00; // set flags to zero including reserved
+   buffer[0] |= 0x07 & (l-1); // field L
+   // (len_mac - 2)/2 shifted left es corresponds to (len_mac - 2) << 2
+   buffer[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
+   buffer[0] |= len_a != 0 ? 0x40 : 0; // field Adata
+
+   memcpy(&buffer[1], nonce, 13);
+
+   if (l == 3) {
+      buffer[13] = 0;
+   }
+
+   buffer[14] = 0;
+   buffer[15] = len_m;
+
+   len = 16;
+   // len(a)
+   if(len_a > 0) {
+      buffer[16] = 0;
+      buffer[17] = len_a;
+      len += 2;
+   }
+
+   //  (((x >> 4) + 1)<<4) - x   or    16 - (x % 16) ?
+   // a + padding
+   pad_len = ((((len_a + len - 16) >> 4) + 1) << 4) - (len_a + len - 16);
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], a, len_a);
+   len += len_a;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   // m + padding
+   pad_len = (((len_m >> 4) + 1) << 4) - len_m;
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], m, len_m);
+   len += len_m;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   aes_cbc_enc_raw(buffer, len, cbc_mac_iv);
+
+   // copy MAC
+   memcpy(mac, &buffer[len - 16], len_mac);
+
+   return E_SUCCESS;
+}
+
+/**
+\brief Counter (CTR) mode encryption specific to IEEE 802.15.4E. Assumes key is already
+loaded in the engine.
+\param[in,out] m Pointer to the data that is both authenticated and encrypted. Data is
+   overwritten by ciphertext (i.e. plaintext in case of inverse CCM*).
+\param[in] len_m Length of data that is both authenticated and encrypted.
+\param[in] nonce Buffer containing nonce (13 octets).
+\param[in,out] mac Buffer containing the unencrypted or encrypted CBC-MAC tag, which depends
+   on weather the function is called as part of CCM* forward or inverse transformation. It
+   is overwrriten by the encrypted, i.e unencrypted, tag on return.
+\param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
+\param[in] l CCM parameter L that allows selection of different nonce length.
+
+\returns E_SUCCESS when the encryption was successful, E_FAIL otherwise.
+*/
+static owerror_t aes_ctr_enc(uint8_t* m,
+         uint8_t len_m,
+         uint8_t* nonce,
+         uint8_t* mac,
+         uint8_t len_mac,
+         uint8_t l) {
+
+   uint8_t pad_len;
+   uint8_t len;
+   uint8_t iv[16];
+   uint8_t buffer[128 + 16]; // max buffer plus mac
+
+   // asserts here
+   if (!((len_mac == 0) || (len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
+      return E_FAIL;
+   }
+
+   if (len_m > 127) {
+      return E_FAIL;
+   }
+
+   // iv (flag (1B) | source addr (8B) | ASN (5B) | cnt (2B)
+   iv[0] = 0x00;
+   iv[0] |= 0x07 & (l-1); // field L
+
+   memcpy(&iv[1], nonce, 13);
+   iv[14] = 0x00;
+   iv[15] = 0x00;
+
+   // first block is mac
+   memcpy(buffer, mac, len_mac);
+   memset(&buffer[len_mac], 0, 16 - len_mac);
+   len = 16;
+
+   //  (((x >> 4) + 1)<<4) - x   or    16 - (x % 16) ?
+   // m + padding
+   pad_len = (((len_m >> 4) + 1) << 4) - len_m;
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], m, len_m);
+   len += len_m;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   aes_ctr_enc_raw(buffer, len, iv);
+
+   memcpy(m, &buffer[16], len_m);
+   memcpy(mac, buffer, len_mac);
+
+   return E_SUCCESS;
+}
+
+/**
+\brief Raw AES-CTR encryption. Assumes key is already loaded in the engine.
+\param[in,out] buffer Message to be encrypted. Will be overwritten by ciphertext.
+\param[in] len Message length. Must be multiple of 16 octets.
+\param[in] iv Buffer containing the Initialization Vector (16 octets).
+
+\returns E_SUCCESS when the encryption was successful.
+*/
+owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
+   uint8_t n;
+   uint8_t k;
+   uint8_t nb;
+   uint8_t* pbuf;
+   uint8_t eiv[16];
+
+   nb = len >> 4;
+   for (n = 0; n < nb; n++) {
+      pbuf = &buffer[16 * n];
+      memcpy(eiv, iv, 16);
+      at86rf231_crypto_opt_ecb(eiv);
+      // may be faster if vector are aligned to 4 bytes (use long instead char in xor)
+      for (k = 0; k < 16; k++) {
+         pbuf[k] ^= eiv[k];
+      }
+      inc_counter(iv);
+   }
+
+   return E_SUCCESS;
+}
+
+static void inc_counter(uint8_t* counter) {
+   // from openssl
+   uint32_t n = 16;
+   uint8_t  c;
+   do {
+      --n;
+      c = counter[n];
+      ++c;
+      counter[n] = c;
+      if (c) return;
+   } while (n);
+}
+
 

--- a/bsp/boards/iot-lab_M3/SConscript
+++ b/bsp/boards/iot-lab_M3/SConscript
@@ -22,6 +22,12 @@ source   = \
     Glob('configure/*.c') + \
     Glob('library/STM32F10x_StdPeriph_Lib_V3.5.0/Libraries/STM32F10x_StdPeriph_Driver/src/*.c')
 
+localEnv.Append(
+        CPPPATH =  [
+            os.path.join('#','bsp','chips','at86rf231'),
+        ],
+)
+
 board  = localEnv.Object(source=source) + rf231
 
 Return('board')

--- a/bsp/boards/iot-lab_M3/board.c
+++ b/bsp/boards/iot-lab_M3/board.c
@@ -17,6 +17,7 @@
 #include "debugpins.h"
 #include "opentimers.h"
 #include "gpio.h"
+#include "cryptoengine.h"
 
 //=========================== main ============================================
 
@@ -91,6 +92,7 @@ void board_init(void)
     debugpins_init();
     //enable nvic for the radio
     NVIC_radio();
+    cryptoengine_init();
 }
 
 void board_sleep(void) {

--- a/bsp/boards/iot-lab_M3/cryptoengine.c
+++ b/bsp/boards/iot-lab_M3/cryptoengine.c
@@ -1,5 +1,5 @@
 /**
-\brief Dummy implementation of cryptoengine.
+\brief Implementation of cryptoengine based on AT86RF231's hardware accelerator.
 */
 
 #include <stdint.h>
@@ -14,10 +14,9 @@ owerror_t at86rf231_crypto_load_key(uint8_t key[16]);
 owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer);
 static owerror_t aes_cbc_mac(uint8_t* a, uint8_t len_a, uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
 static owerror_t aes_ctr_enc(uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
-owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]); 
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]);
 owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]);
-static void inc_counter(uint8_t* counter); 
-
+static void inc_counter(uint8_t* counter);
 
 //=========================== public ==========================================
 
@@ -136,7 +135,7 @@ owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer) {
             sizeof(spi_rx_buffer),
             SPI_NOTFIRST,
             SPI_LAST);
-    
+
     // Prepare to read the AES status register
     spi_tx_buffer[0] = 0x00;
     spi_tx_buffer[1] = RG_AES_STATUS;
@@ -178,7 +177,7 @@ owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer) {
                 16,
                 SPI_NOTFIRST,
                 SPI_LAST);
-    
+
     return E_SUCCESS;
 }
 
@@ -211,13 +210,13 @@ owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
 }
 
 /**
-\brief Raw AES-CBC encryption omitting everything but the last block. Assumes key 
+\brief Raw AES-CBC encryption omitting everything but the last block. Assumes key
     is already loaded in the engine.
 \param[in,out] buffer Message to be encrypted. First and last block will be overwritten.
 \param[in] len Message length. Must be multiple of 16 octets.
 \param[in] iv Buffer containing the Initialization Vector (16 octets).
 
-\returns E_SUCCESS when the encryption was successful. 
+\returns E_SUCCESS when the encryption was successful.
 */
 owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
     uint8_t  n;
@@ -270,7 +269,7 @@ owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
                 sizeof(spi_rx_buffer),
                 SPI_NOTFIRST,
                 SPI_LAST);
-    
+
         // Prepare to read the AES status register
         spi_tx_buffer[0] = 0x00;
         spi_tx_buffer[1] = RG_AES_STATUS;
@@ -329,7 +328,7 @@ engine.
 \param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
 \param[in] l CCM parameter L that allows selection of different nonce length.
 
-\returns E_SUCCESS when the generation was successful, E_FAIL otherwise. 
+\returns E_SUCCESS when the generation was successful, E_FAIL otherwise.
 */
 static owerror_t aes_cbc_mac(uint8_t* a,
          uint8_t len_a,
@@ -339,7 +338,7 @@ static owerror_t aes_cbc_mac(uint8_t* a,
          uint8_t* mac,
          uint8_t len_mac,
          uint8_t l) {
-   
+
    uint8_t  pad_len;
    uint8_t  len;
    uint8_t  cbc_mac_iv[16];
@@ -367,7 +366,7 @@ static owerror_t aes_cbc_mac(uint8_t* a,
    // (len_mac - 2)/2 shifted left es corresponds to (len_mac - 2) << 2
    buffer[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
    buffer[0] |= len_a != 0 ? 0x40 : 0; // field Adata
-   
+
    memcpy(&buffer[1], nonce, 13);
 
    if (l == 3) {
@@ -423,7 +422,7 @@ loaded in the engine.
 \param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
 \param[in] l CCM parameter L that allows selection of different nonce length.
 
-\returns E_SUCCESS when the encryption was successful, E_FAIL otherwise. 
+\returns E_SUCCESS when the encryption was successful, E_FAIL otherwise.
 */
 static owerror_t aes_ctr_enc(uint8_t* m,
          uint8_t len_m,
@@ -482,7 +481,7 @@ static owerror_t aes_ctr_enc(uint8_t* m,
 \param[in] len Message length. Must be multiple of 16 octets.
 \param[in] iv Buffer containing the Initialization Vector (16 octets).
 
-\returns E_SUCCESS when the encryption was successful. 
+\returns E_SUCCESS when the encryption was successful.
 */
 owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
    uint8_t n;

--- a/bsp/boards/iot-lab_M3/cryptoengine.c
+++ b/bsp/boards/iot-lab_M3/cryptoengine.c
@@ -4,7 +4,16 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "at86rf231.h"
 #include "cryptoengine.h"
+#include "spi.h"
+#include "radio.h"
+
+//=========================== prototypes ======================================
+owerror_t at86rf231_crypto_load_key(uint8_t key[16]);
+owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer);
+
+//=========================== public ==========================================
 
 owerror_t cryptoengine_aes_ccms_enc(uint8_t* a,
          uint8_t len_a,
@@ -31,10 +40,129 @@ owerror_t cryptoengine_aes_ccms_dec(uint8_t* a,
 }
 
 owerror_t cryptoengine_aes_ecb_enc(uint8_t* buffer, uint8_t* key) {
-   return E_FAIL;
+    if (at86rf231_crypto_load_key(key) == E_SUCCESS) {
+        at86rf231_crypto_opt_ecb(buffer);
+        return E_SUCCESS;
+    }
+    return E_FAIL;
 }
 
 owerror_t cryptoengine_init(void) {
-   return E_SUCCESS;
+    radio_rfOn();
+    return E_SUCCESS;
+}
+
+//=========================== private =========================================
+// Optimized ECB AES encryption that does not load the key beforehand
+owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer) {
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+
+    uint8_t aes_cmd;
+    uint8_t aes_status;
+
+    aes_cmd = 0x80; // AES start
+    aes_status = 0x00;
+
+    spi_tx_buffer[0] = 0x40; // SRAM write
+    spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+    spi_tx_buffer[2] = 0x00; // ECB encryption
+
+    spi_txrx(spi_tx_buffer,
+            sizeof(spi_tx_buffer),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_FIRST,
+            SPI_NOTLAST);
+
+    spi_txrx((uint8_t*)buffer,
+            16,
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_NOTLAST);
+
+    spi_txrx(&aes_cmd,
+            sizeof(aes_cmd),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_LAST);
+    
+    // Prepare to read the AES status register
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATUS;
+
+    // Busy wait reading AES status register until it is done or an error occurs
+    do {
+        spi_txrx(spi_tx_buffer,
+                sizeof(spi_tx_buffer),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_FIRST,
+                SPI_LAST);
+        aes_status = spi_rx_buffer[2];
+    } while((aes_status & 0x01) == 0x00);
+
+    if ((aes_status & 0x80) == 0x01) {
+        // an error occured
+        return E_FAIL;
+    }
+
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATE_KEY;
+
+    // send the command to read the ciphertext
+    spi_txrx(spi_tx_buffer,
+                2,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                16,
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+    // read the actual ciphertext
+    spi_txrx(spi_tx_buffer,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)buffer,
+                16,
+                SPI_NOTFIRST,
+                SPI_LAST);
+    
+    return E_SUCCESS;
+}
+
+
+owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+    uint8_t aes_cmd;
+
+    spi_tx_buffer[0] = 0x40; // SRAM write
+    spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+    spi_tx_buffer[2] = 0x10; // key mode
+
+    spi_txrx(spi_tx_buffer,
+            sizeof(spi_tx_buffer),
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_FIRST,
+            SPI_NOTLAST);
+
+    spi_txrx((uint8_t*)key,
+            16,
+            SPI_BUFFER,
+            (uint8_t*)spi_rx_buffer,
+            sizeof(spi_rx_buffer),
+            SPI_NOTFIRST,
+            SPI_LAST);
+
+    return E_SUCCESS;
 }
 

--- a/bsp/boards/iot-lab_M3/cryptoengine.c
+++ b/bsp/boards/iot-lab_M3/cryptoengine.c
@@ -12,6 +12,12 @@
 //=========================== prototypes ======================================
 owerror_t at86rf231_crypto_load_key(uint8_t key[16]);
 owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer);
+static owerror_t aes_cbc_mac(uint8_t* a, uint8_t len_a, uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
+static owerror_t aes_ctr_enc(uint8_t* m, uint8_t len_m, uint8_t* nonce, uint8_t* mac, uint8_t len_mac, uint8_t l);
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]); 
+owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]);
+static void inc_counter(uint8_t* counter); 
+
 
 //=========================== public ==========================================
 
@@ -23,7 +29,25 @@ owerror_t cryptoengine_aes_ccms_enc(uint8_t* a,
          uint8_t l,
          uint8_t key[16],
          uint8_t len_mac) {
-   
+   uint8_t mac[CBC_MAX_MAC_SIZE];
+
+   if ((len_mac > CBC_MAX_MAC_SIZE) || (l != 2)) {
+      return E_FAIL;
+   }
+
+   if (at86rf231_crypto_load_key(key) != E_SUCCESS) {
+        return E_FAIL;
+   }
+
+   if (aes_cbc_mac(a, len_a, m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+      if (aes_ctr_enc(m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+         memcpy(&m[*len_m], mac, len_mac);
+         *len_m += len_mac;
+
+         return E_SUCCESS;
+      }
+   }
+
    return E_FAIL;
 }
 
@@ -35,7 +59,28 @@ owerror_t cryptoengine_aes_ccms_dec(uint8_t* a,
          uint8_t l,
          uint8_t key[16],
          uint8_t len_mac) {
-   
+   uint8_t mac[CBC_MAX_MAC_SIZE];
+   uint8_t orig_mac[CBC_MAX_MAC_SIZE];
+
+   if ((len_mac > CBC_MAX_MAC_SIZE) || (l != 2)) {
+      return E_FAIL;
+   }
+
+   if (at86rf231_crypto_load_key(key) != E_SUCCESS) {
+        return E_FAIL;
+   }
+
+   *len_m -= len_mac;
+   memcpy(mac, &m[*len_m], len_mac);
+
+   if (aes_ctr_enc(m, *len_m, nonce, mac, len_mac, l) == E_SUCCESS) {
+      if (aes_cbc_mac(a, len_a, m, *len_m, nonce, orig_mac, len_mac, l) == E_SUCCESS) {
+         if (memcmp(mac, orig_mac, len_mac) == 0) {
+            return E_SUCCESS;
+         }
+      }
+   }
+
    return E_FAIL;
 }
 
@@ -141,7 +186,6 @@ owerror_t at86rf231_crypto_opt_ecb(uint8_t* buffer) {
 owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
     uint8_t spi_tx_buffer[3];
     uint8_t spi_rx_buffer[16];
-    uint8_t aes_cmd;
 
     spi_tx_buffer[0] = 0x40; // SRAM write
     spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
@@ -165,4 +209,236 @@ owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
 
     return E_SUCCESS;
 }
+
+/**
+\brief CBC-MAC generation specific to CCM*. Assumes key is already loaded in the
+engine.
+\param[in] a Pointer to the authentication only data.
+\param[in] len_a Length of authentication only data.
+\param[in] m Pointer to the data that is both authenticated and encrypted.
+\param[in] len_m Length of data that is both authenticated and encrypted.
+\param[in] nonce Buffer containing nonce (13 octets).
+\param[out] mac Buffer where the value of the CBC-MAC tag will be written.
+\param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
+\param[in] l CCM parameter L that allows selection of different nonce length.
+
+\returns E_SUCCESS when the generation was successful, E_FAIL otherwise. 
+*/
+static owerror_t aes_cbc_mac(uint8_t* a,
+         uint8_t len_a,
+         uint8_t* m,
+         uint8_t len_m,
+         uint8_t* nonce,
+         uint8_t* mac,
+         uint8_t len_mac,
+         uint8_t l) {
+   
+   uint8_t  pad_len;
+   uint8_t  len;
+   uint8_t  cbc_mac_iv[16];
+   uint8_t  buffer[128+16+16]; // max buffer plus IV
+
+   // asserts here
+   if (!((len_mac == 0) || (len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
+      return E_FAIL;
+   }
+
+   if ((len_a > 127) || (len_m > 127) || ((len_a + len_m) > 127)) {
+      return E_FAIL;
+   }
+
+   if (mac == 0) {
+      return E_FAIL;
+   }
+
+   memset(cbc_mac_iv, 0x00, 16); // CBC-MAC Initialization Vector is a zero string
+
+   // IV: flags (1B) | SADDR (8B) | ASN (5B) | len(m) (2B)
+   // X0 xor IV in first 16 bytes of buffer: set buffer[:16] as IV)
+   buffer[0] = 0x00; // set flags to zero including reserved
+   buffer[0] |= 0x07 & (l-1); // field L
+   // (len_mac - 2)/2 shifted left es corresponds to (len_mac - 2) << 2
+   buffer[0] |= len_mac == 0 ? 0 : (0x07 & (len_mac - 2)) << 2; // field M
+   buffer[0] |= len_a != 0 ? 0x40 : 0; // field Adata
+   
+   memcpy(&buffer[1], nonce, 13);
+
+   if (l == 3) {
+      buffer[13] = 0;
+   }
+
+   buffer[14] = 0;
+   buffer[15] = len_m;
+
+   len = 16;
+   // len(a)
+   if(len_a > 0) {
+      buffer[16] = 0;
+      buffer[17] = len_a;
+      len += 2;
+   }
+
+   //  (((x >> 4) + 1)<<4) - x   or    16 - (x % 16) ?
+   // a + padding
+   pad_len = ((((len_a + len - 16) >> 4) + 1) << 4) - (len_a + len - 16);
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], a, len_a);
+   len += len_a;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   // m + padding
+   pad_len = (((len_m >> 4) + 1) << 4) - len_m;
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], m, len_m);
+   len += len_m;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   aes_cbc_enc_raw(buffer, len, cbc_mac_iv);
+
+   // copy MAC
+   memcpy(mac, &buffer[len - 16], len_mac);
+
+   return E_SUCCESS;
+}
+
+/**
+\brief Counter (CTR) mode encryption specific to IEEE 802.15.4E. Assumes key is already
+loaded in the engine.
+\param[in,out] m Pointer to the data that is both authenticated and encrypted. Data is
+   overwritten by ciphertext (i.e. plaintext in case of inverse CCM*).
+\param[in] len_m Length of data that is both authenticated and encrypted.
+\param[in] nonce Buffer containing nonce (13 octets).
+\param[in,out] mac Buffer containing the unencrypted or encrypted CBC-MAC tag, which depends
+   on weather the function is called as part of CCM* forward or inverse transformation. It
+   is overwrriten by the encrypted, i.e unencrypted, tag on return.
+\param[in] len_mac Length of the CBC-MAC tag. Must be 4, 8 or 16 octets.
+\param[in] l CCM parameter L that allows selection of different nonce length.
+
+\returns E_SUCCESS when the encryption was successful, E_FAIL otherwise. 
+*/
+static owerror_t aes_ctr_enc(uint8_t* m,
+         uint8_t len_m,
+         uint8_t* nonce,
+         uint8_t* mac,
+         uint8_t len_mac,
+         uint8_t l) {
+
+   uint8_t pad_len;
+   uint8_t len;
+   uint8_t iv[16];
+   uint8_t buffer[128 + 16]; // max buffer plus mac
+
+   // asserts here
+   if (!((len_mac == 0) || (len_mac == 4) || (len_mac == 8) || (len_mac == 16))) {
+      return E_FAIL;
+   }
+
+   if (len_m > 127) {
+      return E_FAIL;
+   }
+
+   // iv (flag (1B) | source addr (8B) | ASN (5B) | cnt (2B)
+   iv[0] = 0x00;
+   iv[0] |= 0x07 & (l-1); // field L
+
+   memcpy(&iv[1], nonce, 13);
+   iv[14] = 0x00;
+   iv[15] = 0x00;
+
+   // first block is mac
+   memcpy(buffer, mac, len_mac);
+   memset(&buffer[len_mac], 0, 16 - len_mac);
+   len = 16;
+
+   //  (((x >> 4) + 1)<<4) - x   or    16 - (x % 16) ?
+   // m + padding
+   pad_len = (((len_m >> 4) + 1) << 4) - len_m;
+   pad_len = pad_len == 16 ? 0 : pad_len;
+   memcpy(&buffer[len], m, len_m);
+   len += len_m;
+   memset(&buffer[len], 0, pad_len);
+   len += pad_len;
+
+   aes_ctr_enc_raw(buffer, len, iv);
+
+   memcpy(m, &buffer[16], len_m);
+   memcpy(mac, buffer, len_mac);
+
+   return E_SUCCESS;
+}
+
+/**
+\brief Raw AES-CBC encryption. Assumes key is already loaded in the engine.
+\param[in,out] buffer Message to be encrypted. Will be overwritten by ciphertext.
+\param[in] len Message length. Must be multiple of 16 octets.
+\param[in] iv Buffer containing the Initialization Vector (16 octets).
+
+\returns E_SUCCESS when the encryption was successful. 
+*/
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
+   uint8_t  n;
+   uint8_t  k;
+   uint8_t  nb;
+   uint8_t* pbuf;
+   uint8_t* pxor;
+
+   nb = len >> 4;
+   pxor = iv;
+   for (n = 0; n < nb; n++) {
+      pbuf = &buffer[16 * n];
+      // may be faster if vector are aligned to 4 bytes (use long instead char in xor)
+      for (k = 0; k < 16; k++) {
+            pbuf[k] ^= pxor[k];
+      }
+      at86rf231_crypto_opt_ecb(pbuf);
+      pxor = pbuf;
+   }
+   return E_SUCCESS;
+}
+
+/**
+\brief Raw AES-CTR encryption. Assumes key is already loaded in the engine.
+\param[in,out] buffer Message to be encrypted. Will be overwritten by ciphertext.
+\param[in] len Message length. Must be multiple of 16 octets.
+\param[in] iv Buffer containing the Initialization Vector (16 octets).
+
+\returns E_SUCCESS when the encryption was successful. 
+*/
+owerror_t aes_ctr_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
+   uint8_t n;
+   uint8_t k;
+   uint8_t nb;
+   uint8_t* pbuf;
+   uint8_t eiv[16];
+
+   nb = len >> 4;
+   for (n = 0; n < nb; n++) {
+      pbuf = &buffer[16 * n];
+      memcpy(eiv, iv, 16);
+      at86rf231_crypto_opt_ecb(eiv);
+      // may be faster if vector are aligned to 4 bytes (use long instead char in xor)
+      for (k = 0; k < 16; k++) {
+         pbuf[k] ^= eiv[k];
+      }
+      inc_counter(iv);
+   }
+
+   return E_SUCCESS;
+}
+
+static void inc_counter(uint8_t* counter) {
+   // from openssl
+   uint32_t n = 16;
+   uint8_t  c;
+   do {
+      --n;
+      c = counter[n];
+      ++c;
+      counter[n] = c;
+      if (c) return;
+   } while (n);
+}
+
 

--- a/bsp/boards/iot-lab_M3/cryptoengine.c
+++ b/bsp/boards/iot-lab_M3/cryptoengine.c
@@ -211,6 +211,113 @@ owerror_t at86rf231_crypto_load_key(uint8_t key[16]) {
 }
 
 /**
+\brief Raw AES-CBC encryption omitting everything but the last block. Assumes key 
+    is already loaded in the engine.
+\param[in,out] buffer Message to be encrypted. First and last block will be overwritten.
+\param[in] len Message length. Must be multiple of 16 octets.
+\param[in] iv Buffer containing the Initialization Vector (16 octets).
+
+\returns E_SUCCESS when the encryption was successful. 
+*/
+owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
+    uint8_t  n;
+    uint8_t  k;
+    uint8_t  nb;
+    uint8_t* pbuf;
+    uint8_t* pxor;
+    uint8_t spi_tx_buffer[3];
+    uint8_t spi_rx_buffer[16];
+    uint8_t aes_cmd;
+    uint8_t aes_status;
+
+    nb = len >> 4;
+    pxor = iv;
+    pbuf = buffer;
+    for (k = 0; k < 16; k++) {
+        pbuf[k] ^= pxor[k];
+    }
+    at86rf231_crypto_opt_ecb(pbuf);
+
+    aes_cmd = 0xA0; // AES-CBC encryption start
+    aes_status = 0x00;
+    // first block already done, start actual CBC processing in hardware
+    for (n = 1; n<nb; n++) {
+        pbuf = &buffer[16 * n];
+        spi_tx_buffer[0] = 0x40; // SRAM write
+        spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
+        spi_tx_buffer[2] = 0x20; // CBC encryption
+
+        spi_txrx(spi_tx_buffer,
+                sizeof(spi_tx_buffer),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+        spi_txrx((uint8_t*)pbuf,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_NOTFIRST,
+                SPI_NOTLAST);
+
+        spi_txrx(&aes_cmd,
+                sizeof(aes_cmd),
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                sizeof(spi_rx_buffer),
+                SPI_NOTFIRST,
+                SPI_LAST);
+    
+        // Prepare to read the AES status register
+        spi_tx_buffer[0] = 0x00;
+        spi_tx_buffer[1] = RG_AES_STATUS;
+
+        // Busy wait reading AES status register until it is done or an error occurs
+        do {
+            spi_txrx(spi_tx_buffer,
+                    sizeof(spi_tx_buffer),
+                    SPI_BUFFER,
+                    (uint8_t*)spi_rx_buffer,
+                    sizeof(spi_rx_buffer),
+                    SPI_FIRST,
+                    SPI_LAST);
+            aes_status = spi_rx_buffer[2];
+        } while((aes_status & 0x01) == 0x00);
+
+        if ((aes_status & 0x80) == 0x01) {
+            // an error occured
+            return E_FAIL;
+        }
+    }
+
+    spi_tx_buffer[0] = 0x00;
+    spi_tx_buffer[1] = RG_AES_STATE_KEY;
+
+    // send the command to read the last block
+    spi_txrx(spi_tx_buffer,
+                2,
+                SPI_BUFFER,
+                (uint8_t*)spi_rx_buffer,
+                16,
+                SPI_FIRST,
+                SPI_NOTLAST);
+
+    // read the actual ciphertext
+    spi_txrx(spi_tx_buffer,
+                16,
+                SPI_BUFFER,
+                (uint8_t*)pbuf,
+                16,
+                SPI_NOTFIRST,
+                SPI_LAST);
+
+   return E_SUCCESS;
+}
+
+/**
 \brief CBC-MAC generation specific to CCM*. Assumes key is already loaded in the
 engine.
 \param[in] a Pointer to the authentication only data.
@@ -365,112 +472,6 @@ static owerror_t aes_ctr_enc(uint8_t* m,
 
    memcpy(m, &buffer[16], len_m);
    memcpy(mac, buffer, len_mac);
-
-   return E_SUCCESS;
-}
-
-/**
-\brief Raw AES-CBC encryption. Assumes key is already loaded in the engine.
-\param[in,out] buffer Message to be encrypted. Will be overwritten by ciphertext.
-\param[in] len Message length. Must be multiple of 16 octets.
-\param[in] iv Buffer containing the Initialization Vector (16 octets).
-
-\returns E_SUCCESS when the encryption was successful. 
-*/
-owerror_t aes_cbc_enc_raw(uint8_t* buffer, uint8_t len, uint8_t iv[16]) {
-    uint8_t  n;
-    uint8_t  k;
-    uint8_t  nb;
-    uint8_t* pbuf;
-    uint8_t* pxor;
-    uint8_t spi_tx_buffer[3];
-    uint8_t spi_rx_buffer[16];
-    uint8_t aes_cmd;
-    uint8_t aes_status;
-
-    nb = len >> 4;
-    pxor = iv;
-    pbuf = buffer;
-    for (k = 0; k < 16; k++) {
-        pbuf[k] ^= pxor[k];
-    }
-    at86rf231_crypto_opt_ecb(pbuf);
-
-    aes_cmd = 0xA0; // AES-CBC encryption start
-    aes_status = 0x00;
-    // first block already done, start actual CBC processing in hardware
-    for (n = 1; n<nb; n++) {
-        pbuf = &buffer[16 * n];
-        spi_tx_buffer[0] = 0x40; // SRAM write
-        spi_tx_buffer[1] = RG_AES_CTRL; // AES_CTRL register
-        spi_tx_buffer[2] = 0x20; // CBC encryption
-
-        spi_txrx(spi_tx_buffer,
-                sizeof(spi_tx_buffer),
-                SPI_BUFFER,
-                (uint8_t*)spi_rx_buffer,
-                sizeof(spi_rx_buffer),
-                SPI_FIRST,
-                SPI_NOTLAST);
-
-        spi_txrx((uint8_t*)pbuf,
-                16,
-                SPI_BUFFER,
-                (uint8_t*)spi_rx_buffer,
-                sizeof(spi_rx_buffer),
-                SPI_NOTFIRST,
-                SPI_NOTLAST);
-
-        spi_txrx(&aes_cmd,
-                sizeof(aes_cmd),
-                SPI_BUFFER,
-                (uint8_t*)spi_rx_buffer,
-                sizeof(spi_rx_buffer),
-                SPI_NOTFIRST,
-                SPI_LAST);
-    
-        // Prepare to read the AES status register
-        spi_tx_buffer[0] = 0x00;
-        spi_tx_buffer[1] = RG_AES_STATUS;
-
-        // Busy wait reading AES status register until it is done or an error occurs
-        do {
-            spi_txrx(spi_tx_buffer,
-                    sizeof(spi_tx_buffer),
-                    SPI_BUFFER,
-                    (uint8_t*)spi_rx_buffer,
-                    sizeof(spi_rx_buffer),
-                    SPI_FIRST,
-                    SPI_LAST);
-            aes_status = spi_rx_buffer[2];
-        } while((aes_status & 0x01) == 0x00);
-
-        if ((aes_status & 0x80) == 0x01) {
-            // an error occured
-            return E_FAIL;
-        }
-
-        spi_tx_buffer[0] = 0x00;
-        spi_tx_buffer[1] = RG_AES_STATE_KEY;
-
-        // send the command to read the ciphertext
-        spi_txrx(spi_tx_buffer,
-                    2,
-                    SPI_BUFFER,
-                    (uint8_t*)spi_rx_buffer,
-                    16,
-                    SPI_FIRST,
-                    SPI_NOTLAST);
-
-        // read the actual ciphertext
-        spi_txrx(spi_tx_buffer,
-                    16,
-                    SPI_BUFFER,
-                    (uint8_t*)pbuf,
-                    16,
-                    SPI_NOTFIRST,
-                    SPI_LAST);
-    }
 
    return E_SUCCESS;
 }

--- a/bsp/chips/at86rf231/at86rf231.h
+++ b/bsp/chips/at86rf231/at86rf231.h
@@ -648,6 +648,9 @@ enum radio_irqstatus_enum {
 # define RG_RX_CTRL                      (0x0a)
 //controls the sensitivity of the antenna diversity mode
 
+# define RG_AES_STATE_KEY                (0x84)
+# define RG_AES_CTRL                     (0x83)
+# define RG_AES_STATUS                   (0x82)
 //=========================== typedef =========================================
 
 //=========================== variables =======================================

--- a/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
+++ b/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
@@ -334,6 +334,8 @@ int mote_main(void) {
 #endif /* TEST_AES_CCMS_AUTH_INVERSE */
 
    board_init();
+
+   leds_all_off();
    
 #if TEST_AES_ECB
    if (run_aes_ecb_suite(aes_ecb_suite, sizeof(aes_ecb_suite)/sizeof(aes_ecb_suite[0])) == E_FAIL) {

--- a/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
+++ b/projects/common/01bsp_cryptoengine/01bsp_cryptoengine.c
@@ -64,7 +64,7 @@ typedef struct
     uint8_t len_tag;
     uint8_t nonce[13];
     uint8_t a[26];
-    uint8_t m[8];               
+    uint8_t m[8];
     uint8_t len_a;
     uint8_t len_m;
     uint8_t l;
@@ -76,7 +76,7 @@ static int hang(uint8_t error_code) {
    error_code ? leds_error_on() : leds_radio_on();
 
    while (1);
-   
+
    return 0;
 }
 
@@ -84,7 +84,7 @@ static int hang(uint8_t error_code) {
 static owerror_t run_aes_ecb_suite(aes_ecb_suite_t* suite, uint8_t test_suite_len) {
    uint8_t i = 0;
    uint8_t success = 0;
-   
+
    for(i = 0; i < test_suite_len; i++) {
       if(cryptoengine_aes_ecb_enc(suite[i].buffer, suite[i].key) == E_SUCCESS) {
          if (memcmp(suite[i].buffer, suite[i].expected_ciphertext, 16) == 0) {
@@ -92,8 +92,8 @@ static owerror_t run_aes_ecb_suite(aes_ecb_suite_t* suite, uint8_t test_suite_le
          }
       }
    }
-   
-   return success == test_suite_len ? E_SUCCESS : E_FAIL; 
+
+   return success == test_suite_len ? E_SUCCESS : E_FAIL;
 }
 #endif /* TEST_AES_ECB */
 
@@ -111,13 +111,13 @@ static owerror_t run_aes_ccms_enc_suite(aes_ccms_enc_suite_t* suite, uint8_t tes
                   suite[i].l,
                   suite[i].key,
                   suite[i].len_tag) == E_SUCCESS) {
-         
+
          if(memcmp(suite[i].m, suite[i].expected_ciphertext, suite[i].len_m) == 0) {
             success++;
          }
       }
    }
-   return success == test_suite_len ? E_SUCCESS : E_FAIL; 
+   return success == test_suite_len ? E_SUCCESS : E_FAIL;
 }
 #endif /* TEST_AES_CCMS_ENC */
 
@@ -136,13 +136,13 @@ static owerror_t run_aes_ccms_dec_suite(aes_ccms_dec_suite_t* suite, uint8_t tes
                        suite[i].l,
                        suite[i].key,
                        suite[i].len_tag) == E_SUCCESS) {
-         
+
          if(memcmp(suite[i].c, suite[i].expected_plaintext, suite[i].len_c) == 0) {
             success++;
          }
       }
    }
-   return success == test_suite_len ? E_SUCCESS : E_FAIL; 
+   return success == test_suite_len ? E_SUCCESS : E_FAIL;
 }
 #endif /* TEST_AES_CCMS_DEC */
 
@@ -161,13 +161,13 @@ static owerror_t run_aes_ccms_auth_forward_suite(aes_ccms_auth_forward_suite_t* 
                   suite[i].l,
                   suite[i].key,
                   suite[i].len_tag) == E_SUCCESS) {
-         
+
          if(memcmp(suite[i].m, suite[i].expected_ciphertext, suite[i].len_tag) == 0) {
             success++;
          }
       }
    }
-   return success == test_suite_len ? E_SUCCESS : E_FAIL; 
+   return success == test_suite_len ? E_SUCCESS : E_FAIL;
 }
 #endif /* TEST_AES_CCMS_AUTH_FORWARD */
 
@@ -187,13 +187,13 @@ static owerror_t run_aes_ccms_auth_inverse_suite(aes_ccms_auth_forward_suite_t* 
                        suite[i].l,
                        suite[i].key,
                        suite[i].len_tag) == E_SUCCESS) {
-         
+
          if(memcmp(suite[i].m, suite[i].expected_ciphertext, suite[i].len_tag) == 0) {
             success++;
          }
       }
    }
-   return success == test_suite_len ? E_SUCCESS : E_FAIL; 
+   return success == test_suite_len ? E_SUCCESS : E_FAIL;
 }
 #endif /* TEST_AES_CCMS_AUTH_INVERSE */
 
@@ -253,7 +253,7 @@ int mote_main(void) {
       {
          { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, /* key */
             4, /* tag_len */
-         { 0x00, 0x00, 0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x05 }, /* nonce */ 
+         { 0x00, 0x00, 0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x05 }, /* nonce */
          { 0x69, 0x98, 0x03, 0x33, 0x63, 0xbb, 0xaa, 0x01, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x03}, /* a vector */
          { 0x14, 0xaa, 0xbb, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
             0x0c, 0x0d, 0x0e, 0x0f, 0x00, 0x00, 0x00, 0x00 }, /* m vector + 4 octets for authentication tag */
@@ -269,7 +269,7 @@ int mote_main(void) {
 #if TEST_AES_CCMS_DEC
    aes_ccms_dec_suite_t aes_ccms_dec_suite[] = {
 
-    { 
+    {
         { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, /* key */
         0, /* tag len */
         { 0x00, 0x00, 0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x05 }, /* nonce */
@@ -318,7 +318,7 @@ int mote_main(void) {
 
 #if TEST_AES_CCMS_AUTH_INVERSE
    aes_ccms_auth_forward_suite_t aes_ccms_auth_inverse_suite[] = {
-    { 
+    {
         {0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF}, /* key */
         8, /* tag len */
         {0xAC, 0xDE, 0x48, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05, 0x02}, /* nonce */
@@ -336,7 +336,7 @@ int mote_main(void) {
    board_init();
 
    leds_all_off();
-   
+
 #if TEST_AES_ECB
    if (run_aes_ecb_suite(aes_ecb_suite, sizeof(aes_ecb_suite)/sizeof(aes_ecb_suite[0])) == E_FAIL) {
       fail++;
@@ -356,14 +356,14 @@ int mote_main(void) {
 #endif /* TEST_AES_CCMS_DEC */
 
 #if TEST_AES_CCMS_AUTH_FORWARD
-   if (run_aes_ccms_auth_forward_suite(aes_ccms_auth_forward_suite, 
+   if (run_aes_ccms_auth_forward_suite(aes_ccms_auth_forward_suite,
             sizeof(aes_ccms_auth_forward_suite)/sizeof(aes_ccms_auth_forward_suite[0])) == E_FAIL) {
       fail++;
    }
 #endif /* TEST_AES_CCMS_AUTH_FORWARD */
 
 #if TEST_AES_CCMS_AUTH_INVERSE
-   if (run_aes_ccms_auth_inverse_suite(aes_ccms_auth_inverse_suite, 
+   if (run_aes_ccms_auth_inverse_suite(aes_ccms_auth_inverse_suite,
             sizeof(aes_ccms_auth_inverse_suite)/sizeof(aes_ccms_auth_inverse_suite[0])) == E_FAIL) {
       fail++;
    }
@@ -385,7 +385,7 @@ int mote_main(void) {
 
    memset(a, 0xfe, A_LEN);
    memset(m, 0xab, M_LEN);
-   
+
    PORT_TIMER_WIDTH time1 = 0;
    PORT_TIMER_WIDTH time2 = 0;
    PORT_TIMER_WIDTH enc = 0;


### PR DESCRIPTION
This PR adds support for CCM at iotlab-m3 nodes and their derivatives. It implements the CCM using hardware acceleration available in the AT86RF231 chip. While the CCM implementation passes all the unit tests available, its performance is bad due to the SPI transfer. For CCM to complete on a 127-byte frame, it takes ~5ms, making it impossible to use it for link-layer security processing.
The provided CCM implementation enables the secure join protocol to complete, so it is therefore deemed useful.