### PR TITLE
FW-855. Critical error: wrong addr type error makes motes reset.

### DIFF
--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -906,6 +906,8 @@ port_INLINE void activity_ti1ORri1(void) {
     // Reset sleep slots
     ieee154e_vars.numOfSleepSlots = 1;
 
+    // update nextActiveSlotOffset before using
+    ieee154e_vars.nextActiveSlotOffset = schedule_getNextActiveSlotOffset();
     if (ieee154e_vars.slotOffset==ieee154e_vars.nextActiveSlotOffset) {
         // this is the next active slot
 
@@ -2946,8 +2948,7 @@ void endSlot(void) {
         } else {
             // update numelapsed on rx cell (msf will check whether it
             // is to parent or not)
-            schedule_getNeighbor(&slotNeighbor);
-            msf_updateCellsElapsed(&slotNeighbor, CELLTYPE_RX);
+            msf_updateCellsElapsed(&info.address, CELLTYPE_RX);
         }
     }
     ieee154e_vars.receivedFrameFromParent = FALSE;


### PR DESCRIPTION
FW-855. update nextActiveSlotOffset before using in case the currentScheduleEntry's next pointer changes. (new cell added/deleted)
