### PR TITLE
FW-856: security_isConfigured() for DAGroot to enable EB 

### DIFF
--- a/openstack/02a-MAClow/IEEE802154_security.c
+++ b/openstack/02a-MAClow/IEEE802154_security.c
@@ -66,6 +66,10 @@ void IEEE802154_security_setDataKey(uint8_t index, uint8_t* value) {
 }
 
 bool IEEE802154_security_isConfigured(void) {
+    if (idmanager_getIsDAGroot()==TRUE) {
+        return TRUE;
+    }
+   
     if (ieee802154_security_vars.dynamicKeying == FALSE) {
         return TRUE;
     }


### PR DESCRIPTION
We assume the dagroot has the keys and is ready after the initialization.

Else, IEEE802154_security_isConfigured(void) always returns FALSE, and the Dagroot is never able to send an EB. As a consequence, no other device can join the network (no possibility to be synced).

I'm not a security expert, and I assume that the keys are correctly configured after the initialization of the DAGROOT (in the openapp cjoin.c)
