### PR TITLE
openwsn: improve iotlab-m3 support

### DIFF
--- a/bootloader/iot-lab_M3/iotlab-m3-bsl.py
+++ b/bootloader/iot-lab_M3/iotlab-m3-bsl.py
@@ -6,8 +6,7 @@ from subprocess import call
 
 currentDir = os.path.dirname(os.path.realpath(__file__))
 
-OOCD_TARGET='stm32f1x'
-OOCD_ITF=os.path.join(currentDir, 'iotlab-m3.cfg')
+OOCD_CONFIG=os.path.join(currentDir, 'iotlab-m3.cfg')
 
 OOCD_PORT = '123'
 GDB_PORT = '3' + OOCD_PORT
@@ -82,8 +81,7 @@ if os.name=='nt':
    binary = '{' + binary + '}'
 
 call([OPENOCD,
-   '-f', os.path.join(currentDir, OOCD_ITF),
-   '-f', os.path.join('target', OOCD_TARGET) + '.cfg',
+   '-f', os.path.join(currentDir, OOCD_CONFIG),
    '-c', 'gdb_port ' + GDB_PORT,
    '-c', 'telnet_port ' + TELNET_PORT,
    '-c', 'tcl_port ' + TCL_PORT,

--- a/bootloader/iot-lab_M3/iotlab-m3.cfg
+++ b/bootloader/iot-lab_M3/iotlab-m3.cfg
@@ -1,16 +1,8 @@
-# Copied from iot-lab/parts/openlab/platform/scripts/iotlab-m3.cfg
-
-adapter_khz 1000
-
-# comstick ftdi device
-interface ft2232
-ft2232_layout "usbjtag"
-ft2232_device_desc "FITECO M3"
-ft2232_vid_pid 0x0403 0x6010
-
-jtag_nsrst_delay 100
-jtag_ntrst_delay 100
+source [find interface/ftdi/iotlab-usb.cfg]
+source [find target/stm32f1x.cfg]
 
 # use combined on interfaces or targets that can't set TRST/SRST separately
-reset_config trst_and_srst
+reset_config trst_and_srst connect_assert_srst
+
+$_TARGETNAME configure -rtos auto
 

--- a/bsp/boards/iot-lab_M3/stm32_flash.ld
+++ b/bsp/boards/iot-lab_M3/stm32_flash.ld
@@ -15,7 +15,7 @@
 **
 **  Environment : Atollic TrueSTUDIO(R)
 **
-**  Distribution: The file is distributed “as is,” without any warranty
+**  Distribution: The file is distributed ï¿½as is,ï¿½ without any warranty
 **                of any kind.
 **
 **  (c)Copyright Atollic AB.
@@ -145,8 +145,8 @@ SECTIONS
 	{
 		PROVIDE(__heap1_start = .);
 		. = . + __heap1_size;
-		PROVIDE(__heap1_max = .);	
-	} > RAM	
+		PROVIDE(__heap1_max = .);
+	} > RAM
 
   /*
   PROVIDE ( end = _ebss );

--- a/bsp/boards/iot-lab_M3/stm32_flash.ld
+++ b/bsp/boards/iot-lab_M3/stm32_flash.ld
@@ -88,12 +88,14 @@ SECTIONS
 
   .preinit_array     :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
   .init_array :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
@@ -101,6 +103,7 @@ SECTIONS
   } >FLASH
   .fini_array :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(.fini_array*))
     KEEP (*(SORT(.fini_array.*)))


### PR DESCRIPTION
This PR fixes the `openocd` script used for flashing iot-lab_M3 nodes by using the defaults ones already present in `openocd`, I've taken it from the script used in `RIOT`.

<details><summary><b>scons board=iot-lab_M3 bootload=/dev/ttyUSB1 toolchain=armgcc oos_openwsn</b></summary>

```

scons: Reading SConscript files ...

 ___                 _ _ _  ___  _ _ 
| . | ___  ___ ._ _ | | | |/ __>| \ |
| | || . \/ ._>| ' || | | |\__ \|   |
`___'|  _/\___.|_|_||__/_/ <___/|_\_|
     |_|                  openwsn.org

none
scons: done reading SConscript files.
scons: Building targets ...
Dynifying build/iot-lab_M3_armgcc/openapps/openapps_dyn.c
arm-none-eabi-size --format=berkeley -x --totals build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog
   text	   data	    bss	    dec	    hex	filename
0x1d648	   0x6c	 0xff94	 185928	  2d648	build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog
0x1d648	   0x6c	 0xff94	 185928	  2d648	(TOTALS)
IotLabM3_bootload(["build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog.phonyupload"], ["build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog.ihex"])
starting bootloading on /dev/riot/tty-iotlab-m3
Open On-Chip Debugger 0.10.0+dev-00703-g92bb76a4-dirty (2019-07-19-14:27)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
adapter speed: 1000 kHz
Error: The specified debug interface was not found (ft2232)
The following debug interfaces are available:
1: ftdi
2: usb_blaster
3: ft232r
4: presto
5: usbprog
6: openjtag
7: jlink
8: vsllink
9: rlink
10: ulink
11: arm-jtag-ew
12: hla
13: osbdm
14: opendous
15: aice
16: cmsis-dap
17: kitprog
18: xds110
done bootloading on /dev/riot/tty-iotlab-m3
scons: done building targets.
```

</details>

It also fixes a compile issue present when using newer `armgcc` toolchain, this results in unaligned firmware which is then imposible to flash using the openocd script. I replicated the issue in the following toolchains:

- arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2018-q2-update) 7.3.1 20180622 (release) [ARM/embedded-7-branch revision 261907]
- arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 8-2018-q4-major) 8.2.1 20181213 (release) [gcc-8-branch revision 267074]

<details><summary><b>scons board=iot-lab_M3  bootload=/dev/ttyUSB1 toolchain=armgcc oos_openwsn</b></summary>

```
Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020 (STMicroelectronics), part: 0x6414, ver: 0x0)
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0801c234 msp: 0x20010000
auto erase enabled
Info : device id = 0x10016414
Info : flash size = 512kbytes
Info : Flash write discontinued at 0x0801d648, next section at 0x0801e13d
Warn : Adding extra erase range, 0x0001e000 to 0x0001e13c
Error: offset 0x1e13d breaks required 2-byte alignment
Error: error writing to flash at address 0x08000000 at offset 0x0001e13d

done bootloading on /dev/riot/tty-iotlab-m3
scons: done building targets.
```
</details>
Its is not present in:

- arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 4.9.3 20150303 (release) [ARM/embedded-4_9-branch revision 221220]

### Testing Procedure with iotlab-a8-m3

**NOTE** you can't test the first error in iotlab since they use their own openocd configuration script.

- Book an experiment with `a8-m3` either do it on the dashboard or if `iotlab-cli` is isntalled (`pip install iotlab-cli`). Change the node id if that one is booked

```
$ iotlab-experiment submit -d 120 -l grenoble,a8,100
{
    "id": 205639
}
```

```
$ iotlab-experiment wait --id 205639
Waiting that experiment 205639 gets in state Running
"Running"
```

If you have one of the newer toolchain versions you can try building and flashing directly from your local host by installing `iotlabsshcli` (`pip install iotlabsshcli`):

- Build: `scons board=iot-lab_A8-M3 toolchain=armgcc oos_openwsn`

- Flash:

With this PR:

```
iotlab-ssh lash-m3 build/iot-lab_A8-M3_armgcc/projects/common/03oos_openwsn_prog -l grenoble,a8,100

{
    "flash-m3": {
        "0": [
            "node-a8-100.grenoble.iot-lab.info"
        ]
}
```

Without this PR (sadly iotlab doesn't give more info than an invalid return code 1 instead of 0):

```
iotlab-ssh flash-m3 build/iot-lab_A8-M3_armgcc/projects/common/03oos_openwsn_prog -l grenoble,a8,100

{
    "flash-m3": {
        "1": [
            "node-a8-100.grenoble.iot-lab.info"
        ]
}
```
