### PR TITLE
specify python version

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -600,7 +600,7 @@ class telosb_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python '+os.path.join('bootloader','telosb','bsl')+' --telosb -c {0} -r -e -I -p "{1}"'.format(self.comPort,self.hexFile),
+            'python2 '+os.path.join('bootloader','telosb','bsl')+' --telosb -c {0} -r -e -I -p "{1}"'.format(self.comPort,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -642,7 +642,7 @@ class OpenMoteCC2538_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python '+os.path.join('bootloader','openmote-cc2538','cc2538-bsl.py')+' -e --bootloader-invert-lines -w -b 400000 -p {0} {1}'.format(self.comPort,self.hexFile),
+            'python2 '+os.path.join('bootloader','openmote-cc2538','cc2538-bsl.py')+' -e --bootloader-invert-lines -w -b 400000 -p {0} {1}'.format(self.comPort,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -697,7 +697,7 @@ class opentestbed_bootloadThread(threading.Thread):
         else:
             target  = self.mote
         subprocess.call(
-            'python '+os.path.join('bootloader','openmote-cc2538','ot_program.py')+' -a {0} {1}'.format(target,self.hexFile),
+            'python2 '+os.path.join('bootloader','openmote-cc2538','ot_program.py')+' -a {0} {1}'.format(target,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.mote)
@@ -744,7 +744,7 @@ class openmotestm_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python '+ os.path.join('bootloader','openmotestm','bin.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
+            'python2 '+ os.path.join('bootloader','openmotestm','bin.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -786,7 +786,7 @@ class IotLabM3_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python '+ os.path.join('bootloader','iot-lab_M3','iotlab-m3-bsl.py' + ' -i {0} -p {1}'.format(self.binaryFile, self.comPort)),
+            'python2 '+ os.path.join('bootloader','iot-lab_M3','iotlab-m3-bsl.py' + ' -i {0} -p {1}'.format(self.binaryFile, self.comPort)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -832,7 +832,7 @@ class scum_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python '+ os.path.join('bootloader','scum','scum_bootloader.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
+            'python2 '+ os.path.join('bootloader','scum','scum_bootloader.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)


### PR DESCRIPTION
`python2` will not be maintained past 2020, modify scripts relying on `python` being `python2` to explicitly call `python2`, if `python2.7` is not the default python you get the following erros:

```
scons board=iot-lab_M3 bootload=/dev/riot/tty-iotlab-m3 toolchain=armgcc oos_openwsn
scons: Reading SConscript files ...

 ___                 _ _ _  ___  _ _ 
| . | ___  ___ ._ _ | | | |/ __>| \ |
| | || . \/ ._>| ' || | | |\__ \|   |
`___'|  _/\___.|_|_||__/_/ <___/|_\_|
     |_|                  openwsn.org

none
scons: done reading SConscript files.
scons: Building targets ...
Dynifying build/iot-lab_M3_armgcc/openapps/openapps_dyn.c
arm-none-eabi-size --format=berkeley -x --totals build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog
   text	   data	    bss	    dec	    hex	filename
0x1d648	   0x6c	 0xff94	 185928	  2d648	build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog
0x1d648	   0x6c	 0xff94	 185928	  2d648	(TOTALS)
IotLabM3_bootload(["build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog.phonyupload"], ["build/iot-lab_M3_armgcc/projects/common/03oos_openwsn_prog.ihex"])
starting bootloading on /dev/riot/tty-iotlab-m3
  File "bootloader/iot-lab_M3/iotlab-m3-bsl.py", line 58
    print str(err) # will print something like "option -a not recognized"
            ^
SyntaxError: invalid syntax
done bootloading on /dev/riot/tty-iotlab-m3
scons: done building targets.
```

On my setup `python` is `python3`, with this changes I can run:

`scons board=iot-lab_M3 bootload=/dev/riot/tty-iotlab-m3 toolchain=armgcc oos_openwsn`

See also https://www.python.org/dev/peps/pep-0394/