### PR TITLE
scons: add disable_ch_hop option

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -48,6 +48,8 @@ if env['noadaptivesync']==1:
     env.Append(CPPDEFINES    = 'NOADAPTIVESYNC')
 if env['l2_security']==1:
     env.Append(CPPDEFINES    = 'L2_SECURITY_ACTIVE')
+if env['fix_channel']>=11 and env['fix_channel']<=26:
+    env.Append(CPPDEFINES    = {'IEEE802154E_SINGLE_CHANNEL' : env['fix_channel']})
 if env['msf_adapting_to_traffic']==1:
     env.Append(CPPDEFINES    = 'MSF_ADAPTING_TO_TRAFFIC')
 if env['printf']==1:

--- a/SConstruct
+++ b/SConstruct
@@ -84,6 +84,8 @@ project:
     printf        Sends the string messages to openvisualizer  
                   0 (off ), 1 (on, default)
     ide           qtcreator
+    fix_channel   Set single channel hopping for debugging
+                  0 (off, default), i (on, channel=i [11:26])
 
     Common variables:
     verbose        Print each complete compile/link command.
@@ -147,6 +149,7 @@ command_line_options = {
     'atmel_24ghz':              ['0','1'],
     'noadaptivesync':           ['0','1'],
     'l2_security':              ['0','1'],
+    'fix_channel':              ['0'] + map(str, range(11, 27)),
     'msf_adapting_to_traffic':  ['0','1'],
     'printf':                   ['1','0'],          # 1=on (default),  0=off
     'deadline_option':          ['0','1'],
@@ -300,6 +303,13 @@ command_line_vars.AddVariables(
         'l2_security',                                     # key
         '',                                                # help
         command_line_options['l2_security'][0],            # default
+        validate_option,                                   # validator
+        int,                                               # converter
+    ),
+    (
+        'fix_channel',                                     # key
+        '',                                                # help
+        command_line_options['fix_channel'][0],            # default
         validate_option,                                   # validator
         int,                                               # converter
     ),

--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -116,7 +116,11 @@ void ieee154e_init(void) {
     memset(&ieee154e_dbg,0,sizeof(ieee154e_dbg_t));
 
     // set singleChannel to 0 to enable channel hopping.
-    ieee154e_vars.singleChannel     = 0;
+#if IEEE802154E_SINGLE_CHANNEL
+    ieee154e_vars.singleChannel     = IEEE802154E_SINGLE_CHANNEL;
+#else
+    ieee154e_vars.singleChannel     = 0; // 0 means channel hopping
+#endif
     ieee154e_vars.isAckEnabled      = TRUE;
     ieee154e_vars.isSecurityEnabled = FALSE;
     ieee154e_vars.slotDuration      = TsSlotDuration;
@@ -560,7 +564,11 @@ port_INLINE void activity_synchronize_newSlot(void) {
         radio_rfOff();
 
         // update record of current channel
+#if IEEE802154E_SINGLE_CHANNEL
+        ieee154e_vars.freq = IEEE802154E_SINGLE_CHANNEL;
+#else
         ieee154e_vars.freq = (openrandom_get16b()&0x0F) + 11;
+#endif
 
         // configure the radio to listen to the frequency
         radio_setFrequency(ieee154e_vars.freq);
@@ -588,7 +596,11 @@ port_INLINE void activity_synchronize_newSlot(void) {
             radio_rfOff();
 
             // update record of current channel
+#if IEEE802154E_SINGLE_CHANNEL
+            ieee154e_vars.freq = IEEE802154E_SINGLE_CHANNEL;
+#else
             ieee154e_vars.freq = (openrandom_get16b()&0x0F) + 11;
+#endif
 
             // configure the radio to listen to the frequency
             radio_setFrequency(ieee154e_vars.freq);


### PR DESCRIPTION
This PR adds a debugging option to disable channel hopping. I've found myself doing this often to speed up synchronization, joining, etc. while developing or debugging. The option disabling channel hopping takes the channel to be set as a parameter:

e.g.:

`scons single_ch_slot=26 board=openmote-b-24ghz bootload=/dev/riot/tty-openmote-b_1 toolchain=armgcc oos_openwsn
`