### PR TITLE
specify python version only for unix

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -10,6 +10,13 @@ from tools import qtcreator as q
 
 Import('env')
 
+# python2/python2.7 are not recognized in windows so use 'python' directly and
+# assume the right version is installed.
+if os.name=='nt':       # Windows
+   PYTHON_PY = 'python '
+elif os.name=='posix':  # Linux
+   PYTHON_PY = 'python2 '
+
 # directory where we put object and linked files
 # WARNING: -c (clean) removes the VARDIR, so it cannot be blank
 env['VARDIR']  = os.path.join('#','build','{0}_{1}'.format(env['board'],env['toolchain']))
@@ -602,7 +609,7 @@ class telosb_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python2 '+os.path.join('bootloader','telosb','bsl')+' --telosb -c {0} -r -e -I -p "{1}"'.format(self.comPort,self.hexFile),
+            PYTHON_PY +  os.path.join('bootloader','telosb','bsl')+' --telosb -c {0} -r -e -I -p "{1}"'.format(self.comPort,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -644,7 +651,7 @@ class OpenMoteCC2538_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python2 '+os.path.join('bootloader','openmote-cc2538','cc2538-bsl.py')+' -e --bootloader-invert-lines -w -b 400000 -p {0} {1}'.format(self.comPort,self.hexFile),
+            PYTHON_PY +  os.path.join('bootloader','openmote-cc2538','cc2538-bsl.py')+' -e --bootloader-invert-lines -w -b 400000 -p {0} {1}'.format(self.comPort,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -699,7 +706,7 @@ class opentestbed_bootloadThread(threading.Thread):
         else:
             target  = self.mote
         subprocess.call(
-            'python2 '+os.path.join('bootloader','openmote-cc2538','ot_program.py')+' -a {0} {1}'.format(target,self.hexFile),
+            PYTHON_PY +  os.path.join('bootloader','openmote-cc2538','ot_program.py')+' -a {0} {1}'.format(target,self.hexFile),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.mote)
@@ -746,7 +753,7 @@ class openmotestm_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python2 '+ os.path.join('bootloader','openmotestm','bin.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
+            PYTHON_PY +  os.path.join('bootloader','openmotestm','bin.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -788,7 +795,7 @@ class IotLabM3_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python2 '+ os.path.join('bootloader','iot-lab_M3','iotlab-m3-bsl.py' + ' -i {0} -p {1}'.format(self.binaryFile, self.comPort)),
+            PYTHON_PY + os.path.join('bootloader','iot-lab_M3','iotlab-m3-bsl.py' + ' -i {0} -p {1}'.format(self.binaryFile, self.comPort)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)
@@ -834,7 +841,7 @@ class scum_bootloadThread(threading.Thread):
     def run(self):
         print 'starting bootloading on {0}'.format(self.comPort)
         subprocess.call(
-            'python2 '+ os.path.join('bootloader','scum','scum_bootloader.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
+            PYTHON_PY +  os.path.join('bootloader','scum','scum_bootloader.py' + ' -p {0} {1}'.format(self.comPort, self.binaryFile)),
             shell=True
         )
         print 'done bootloading on {0}'.format(self.comPort)


### PR DESCRIPTION
`python2` is not recognized in windows so only specify for unix systems.