### PR TITLE
bsp/boards/stm32f1/sctimer: fix time division

### DIFF
--- a/bsp/boards/iot-lab_A8-M3/sctimer.c
+++ b/bsp/boards/iot-lab_A8-M3/sctimer.c
@@ -41,6 +41,7 @@ sctimer_vars_t sctimer_vars;
 void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
+    sctimer_vars.convert = TRUE;
     //enable BKP and PWR, Clock
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_BKP|RCC_APB1Periph_PWR , ENABLE);
     
@@ -126,7 +127,7 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     if (val > OVERFLOW_THRESHOLD && sctimer_vars.convertUnlock){
         // toggle convert
         if (sctimer_vars.convert){
-            sctimer_vars.convert   = TRUE;
+            sctimer_vars.convert   = FALSE;
         } else {
             sctimer_vars.convert   = TRUE;
         }

--- a/bsp/boards/iot-lab_M3/sctimer.c
+++ b/bsp/boards/iot-lab_M3/sctimer.c
@@ -40,6 +40,7 @@ sctimer_vars_t sctimer_vars;
 void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
+    sctimer_vars.convert = TRUE;
     //enable BKP and PWR, Clock
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_BKP|RCC_APB1Periph_PWR , ENABLE);
     
@@ -126,7 +127,7 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     if (val > OVERFLOW_THRESHOLD && sctimer_vars.convertUnlock){
         // toggle convert
         if (sctimer_vars.convert){
-            sctimer_vars.convert   = TRUE;
+            sctimer_vars.convert   = FALSE;
         } else {
             sctimer_vars.convert   = TRUE;
         }

--- a/bsp/boards/openmotestm/sctimer.c
+++ b/bsp/boards/openmotestm/sctimer.c
@@ -41,6 +41,7 @@ sctimer_vars_t sctimer_vars;
 void sctimer_init(void) {
     // clear local variables
     memset(&sctimer_vars,0,sizeof(sctimer_vars_t));
+    sctimer_vars.convert = TRUE;
     //enable BKP and PWR, Clock
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_BKP|RCC_APB1Periph_PWR , ENABLE);
     
@@ -126,7 +127,7 @@ void sctimer_setCompare(PORT_TIMER_WIDTH val) {
     if (val > OVERFLOW_THRESHOLD && sctimer_vars.convertUnlock){
         // toggle convert
         if (sctimer_vars.convert){
-            sctimer_vars.convert   = TRUE;
+            sctimer_vars.convert   = FALSE;
         } else {
             sctimer_vars.convert   = TRUE;
         }


### PR DESCRIPTION
This PR fixes a bug in the time division implementation for stm32f1 boards,  `sctimer_vars.convert` is never set to false, this error would only show up every 2^31/16384.