### PR TITLE
Uncrustify configuration

### DIFF
--- a/uncrustify-openwsn.cfg
+++ b/uncrustify-openwsn.cfg
@@ -1,0 +1,195 @@
+#
+# indentation
+#
+
+indent_with_tabs        = 0                 # 1=indent to level only, 2=indent with tabs
+input_tab_size          = 4                 # original tab size
+output_tab_size         = 4                 # new tab size
+indent_columns          = output_tab_size   #
+indent_label            = 1                 # pos: absolute col, neg: relative column
+indent_switch_case      = 4                 # number
+indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
+indent_align_string     = true              # indent strings broken by '\' so that they line up.
+#
+# line splitting
+#
+
+code_width              = 120      # Try to limit code width to N columns.
+
+#
+# inter-symbol newlines
+#
+
+nl_enum_brace          = remove   # "enum {" vs "enum \n {"
+nl_union_brace         = remove   # "union {" vs "union \n {"
+nl_struct_brace        = remove   # "struct {" vs "struct \n {"
+nl_do_brace            = remove   # "do {" vs "do \n {"
+nl_if_brace            = remove   # "if () {" vs "if () \n {"
+nl_for_brace           = remove   # "for () {" vs "for () \n {"
+nl_else_brace          = remove   # "else {" vs "else \n {"
+nl_while_brace         = remove   # "while () {" vs "while () \n {"
+nl_switch_brace        = remove   # "switch () {" vs "switch () \n {"
+nl_brace_while         = remove   # "} while" vs "} \n while" - cuddle while
+nl_brace_else          = remove   # "} \n else" vs "} else"
+nl_else_if             = remove   # newline between 'else' and 'if'.
+nl_elseif_brace        = remove   # remove newline between 'else if' and '{'.
+nl_fcall_brace         = remove   # "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace          = remove   # "int foo() {" vs "int foo()\n{"
+nl_collapse_empty_body = true     # set while(){\n} to while(){}
+nl_end_of_file         = force    # newline at end of file
+nl_end_of_file_min     = 1        #
+nl_enum_own_lines      = ignore   # newline before first element, after comma, and after last element, in 'enum'.
+
+# important for Python-C code compilation
+nl_func_type_name        = remove   # newline between return type and function name in a function definition
+nl_func_proto_type_name  = remove   # newline between return type and function name in a prototype
+
+nl_func_paren            = remove   # newline between a function name and the opening '(' in the declaration. 
+nl_func_paren_empty      = remove   # 
+nl_func_def_paren        = remove   # newline between a function name and the opening '(' in the definition
+nl_func_def_paren_empty  = remove   #
+nl_func_call_paren       = remove   # newline between a function name and the opening '(' in the call
+nl_func_call_paren_empty = remove   #
+
+nl_func_decl_start              = remove   # newline after '(' in a function declaration.
+nl_func_def_start               = remove   # newline after '(' in a function definition.
+nl_func_decl_start_multi_line   = false    # newline after '(' in a function declaration if '(' and ')' are in different lines
+nl_func_def_start_multi_line    = false    # newline after '(' in a function definition if '(' and ')' are in different lines
+
+nl_func_decl_args               = remove   # newline after each ',' in a function declaration.
+nl_func_def_args                = remove   #
+
+nl_func_decl_args_multi_line    = true
+nl_func_def_args_multi_line     = true
+nl_func_call_start_multi_line   = true
+nl_func_call_end_multi_line     = false
+
+nl_func_decl_end                = remove
+nl_func_def_end                 = remove
+nl_func_decl_end_multi_line     = false
+nl_func_def_end_multi_line      = false
+
+nl_func_decl_empty              = remove
+nl_func_def_empty               = remove
+nl_func_call_empty              = remove
+
+nl_after_func_body              = 2         # must all three be the same
+nl_after_func_body_class        = 2         # must all three be the same
+nl_after_func_body_one_liner    = 2         # must all three be the same
+
+nl_before_if                    = force
+nl_after_if                     = force
+nl_before_for                   = force
+nl_after_for                    = force
+nl_before_while                 = force
+nl_after_while                  = force
+nl_before_switch                = force
+nl_after_switch                 = force
+nl_before_do                    = force
+nl_after_do                     = force
+
+nl_after_label_colon            = true
+nl_after_struct                 = 2         # newlines after '}' or ';' of a struct/enum/union definition.
+nl_comment_func_def             = 1         # number of newlines between a function definition and the function comment
+nl_multi_line_cond              = true      # newline between ')' and '{' if the ')' is on a different line than the if
+
+nl_func_var_def_blk             = 0
+nl_var_def_blk_start            = 1
+nl_var_def_blk_end              = 1
+nl_var_def_blk_in               = 0
+
+nl_typedef_blk_end              = 2
+nl_typedef_blk_in               = 1
+
+nl_return_expr                  = remove    # newline between 'return' and the return expression
+nl_after_semicolon              = true      # newline after semicolons, except in 'for' statements.
+nl_after_brace_close            = true      # add a newline after '}'. Does not apply if followed by a necessary ';'.
+nl_before_return                = true      # put a blank line before 'return' statements, unless after an open brace
+
+nl_after_func_proto             = 1
+nl_after_func_proto_group       = 2
+nl_before_func_body_proto       = 1
+
+nl_squeeze_ifdef                = true
+
+#
+# Source code modifications
+#
+
+mod_paren_on_return        = ignore   # "return 1;" vs "return (1);"
+mod_full_brace_if          = force    # "if() { } else { }" vs "if() else"
+mod_full_brace_while       = force    # force while(); to while(){ \n ; }
+mod_full_brace_for         = force    # force for(); to for(){ \n ; }
+mod_remove_extra_semicolon = true     # remove superfluous semicolons.
+
+#
+# inter-character spacing options
+#
+
+sp_sizeof_paren         = remove   # "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen        = force    # "if (" vs "if("
+sp_after_sparen         = force    # "if () {" vs "if (){"
+sp_inside_braces        = remove   # "{ 1 }" vs "{1}"
+sp_inside_braces_struct = remove   # "{ 1 }" vs "{1}"
+sp_inside_braces_enum   = remove   # "{ 1 }" vs "{1}"
+sp_assign               = add      #
+sp_arith                = add      #
+sp_bool                 = add      #
+sp_compare              = add      #
+sp_after_comma          = add      #
+sp_after_cast           = remove   # "(int) foo vs (int)foo
+sp_func_def_paren       = remove   # "int foo (){" vs "int foo(){"
+sp_func_call_paren      = remove   # "foo (" vs "foo("
+sp_func_proto_paren     = remove   # "int foo ();" vs "int foo();"
+sp_else_brace           = force    # 
+sp_before_ptr_star      = remove   # 
+sp_after_ptr_star       = force    # 
+sp_between_ptr_star     = remove   # 
+sp_inside_paren         = remove   # remove spaces inside parens
+sp_paren_paren          = remove   # remove spaces between nested parens
+sp_inside_sparen        = remove   # remove spaces inside parens for if, while and the like
+sp_inside_braces_empty  = remove   # force while(){ } to while(){}
+sp_attribute_paren      = force
+sp_defined_paren        = remove
+sp_fparen_brace         = force
+sp_before_square        = force    # space before '[' (except '[]').
+sp_sparen_brace         = force    # space between ')' and '{' of of control statements.
+sp_after_byref          = remove   # space after reference sign '&', if followed by a word.
+
+#
+# comments
+#
+
+nl_before_block_comment     = 2     # minimum number of newlines before a multi-line comment. Doesn't apply if after a brace open or another multi-line comment.
+nl_before_c_comment         = 1     # minimum number of newlines before a single-line C comment. Doesn't apply if after a brace open or other single-line C comments
+nl_after_multiline_comment  = true  # force a newline after a multi-line comment.
+sp_cmt_cpp_start            = force # space after the opening of a C++ comment
+sp_cmt_cpp_doxygen          = true  #
+sp_before_tr_emb_cmt        = force # space before a trailing or embedded comment.
+sp_num_before_tr_emb_cmt    = 3     # paces before a trailing or embedded comment.
+sp_endif_cmt                = force # overrides 'align_right_cmt_at_col'
+cmt_width                   = 120
+
+#
+# Aligning stuff
+#
+
+align_with_tabs        = false     # use tabs to align
+align_on_tabstop       = true      # align on tabstops
+align_enum_equ_span    = 4         # '=' in enum definition
+align_struct_init_span = 0         # align stuff in a structure init '= { }'
+align_right_cmt_span   = 3         #
+# align_right_cmt_at_col = 60
+align_right_cmt_gap    = 0
+align_var_struct_span  = 3
+align_func_proto_gap   = 1
+align_func_proto_span  = 1
+
+
+
+#
+# enable / disable marker config
+#
+
+disable_processing_cmt          = " begin{code-style-ignore}"
+enable_processing_cmt           = " end{code-style-ignore}"


### PR DESCRIPTION
This PR adds the `uncrustify ` configuration file.

You can install the uncrustify binary on Mac OSX, Linux and Windows
- Linux: `sudo apt install uncrustify`
- Mac OS: `brew install uncrustify`
- Windows: download from [uncrustify](https://sourceforge.net/projects/uncrustify/files/uncrustify/)

Alternatively you can clone the repo and compile the project yourself (latest version)

To run it on your code use:
`uncrustify -c uncrustify-openwsn.cfg -f $FilePath -o $FilePath`  (makes the changes in-place)

I've applied the configuration to a bunch of files in the firmware project and I think the resulting layout looks nice, is properly aligned, and most importantly, improves code readability.

There are a lot of configuration options (700+) and they are all listed here: [](http://uncrustify.sourceforge.net/default.cfg). Some options seem to override other ones. The latter can sometimes lead to weird formatting. I tried my best to remove contradicting configuration options, but it is possible some remain. 

Before we reformat the entire FW repo, I propose that the people who are developing firmware code first try the uncrustify configuration on their local working trees and see if the configuration makes sense (and if they personally agree with the proposed code layout). If we see that it works well on all the files and we've converged on a fixed code layout/style, we can reformat the entire project once. Next, we can add the uncrustify configuration to the Travis builder to enforce future PRs to adhere to the coding style.