### PR TITLE
openstack/02b-MAChigh/neighbors: fix neighbors_isNeighborWithHigherDagGrank

### DIFF
--- a/openstack/02b-MAChigh/neighbors.c
+++ b/openstack/02b-MAChigh/neighbors.c
@@ -246,7 +246,7 @@ bool neighbors_isNeighborWithHigherDAGrank(uint8_t index) {
     bool returnVal;
 
     if (neighbors_vars.neighbors[index].used == TRUE &&
-        neighbors_vars.neighbors[index].DAGrank >= icmpv6rpl_getMyDAGrank()) {
+        neighbors_vars.neighbors[index].DAGrank > icmpv6rpl_getMyDAGrank()) {
         returnVal = TRUE;
     } else {
         returnVal = FALSE;


### PR DESCRIPTION
According to the api:

`returns TRUE if that neighbor is in use and has a higher DAG rank than me, FALSE otherwise.`

Function is currently returning True if they have the same DAG rank.