### PR TITLE
kernel: move scheduler vars definitons to scheduler_types.h

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1141,6 +1141,7 @@ def buildIncludePath(project_dir, local_env):
             CPPPATH=[
                 os.path.join('#', 'inc'),
                 os.path.join('#', 'kernel'),
+                os.path.join('#', 'kernel', 'openos'),
                 os.path.join('#', 'openstack'),
                 os.path.join('#', 'openstack', '02a-MAClow'),
                 os.path.join('#', 'openstack', '02b-MAChigh'),

--- a/drivers/SConscript
+++ b/drivers/SConscript
@@ -49,6 +49,7 @@ else:
     localEnv.Append(
         CPPPATH =  [
             os.path.join('#','drivers','common'),
+            os.path.join('#','kernel', 'openos'),
             # openstack
             os.path.join('#','openstack'),
             os.path.join('#','openstack','02a-MAClow'),

--- a/kernel/openos/SConscript
+++ b/kernel/openos/SConscript
@@ -9,9 +9,13 @@ sources_c = [
     'scheduler.c',
 ]
 
+sources_h = [
+    'scheduler_types.h',
+]
+
 if localEnv['board']=='python':
     
-    for s in sources_c:
+    for s in sources_c + sources_h:
         temp = localEnv.Objectify(
             target = localEnv.ObjectifiedFilename(s),
             source = s,
@@ -26,6 +30,11 @@ else:
     
     localEnv.Append(
         CPPPATH =  [
+            # inc
+            os.path.join('#','inc'),
+            # kernel
+            os.path.join('#','kernel'),
+            os.path.join('#','kernel', 'openos'),
         ],
     )
     

--- a/kernel/openos/scheduler_types.h
+++ b/kernel/openos/scheduler_types.h
@@ -1,0 +1,36 @@
+#ifndef OPENWSN_SCHEDULER_TYPES_H
+#define OPENWSN_SCHEDULER_TYPES_H
+
+/**
+\addtogroup kernel
+\{
+\addtogroup Scheduler
+\{
+*/
+
+#include "opendefs.h"
+
+typedef struct task_llist_t {
+   task_cbt                       cb;
+   task_prio_t                    prio;
+   void*                          next;
+} taskList_item_t;
+
+typedef struct {
+   taskList_item_t                taskBuf[TASK_LIST_DEPTH];
+   taskList_item_t*               task_list;
+   uint8_t                        numTasksCur;
+   uint8_t                        numTasksMax;
+} scheduler_vars_t;
+
+typedef struct {
+   uint8_t                        numTasksCur;
+   uint8_t                        numTasksMax;
+} scheduler_dbg_t;
+
+/**
+\}
+\}
+*/
+
+#endif /* OPENWSN_SCHEDULER_TYPES_H */

--- a/kernel/scheduler.h
+++ b/kernel/scheduler.h
@@ -41,31 +41,16 @@ typedef enum {
 
 typedef void (*task_cbt)(void);
 
-typedef struct task_llist_t {
-   task_cbt                       cb;
-   task_prio_t                    prio;
-   void*                          next;
-} taskList_item_t;
-
 //=========================== module variables ================================
 
-typedef struct {
-   taskList_item_t                taskBuf[TASK_LIST_DEPTH];
-   taskList_item_t*               task_list;
-   uint8_t                        numTasksCur;
-   uint8_t                        numTasksMax;
-} scheduler_vars_t;
-
-typedef struct {
-   uint8_t                        numTasksCur;
-   uint8_t                        numTasksMax;
-} scheduler_dbg_t;
 
 //=========================== prototypes ======================================
 
 void scheduler_init(void);
 void scheduler_start(void);
 void scheduler_push_task(task_cbt task_cb, task_prio_t prio);
+
+#include "scheduler_types.h"
 
 /**
 \}

--- a/openstack/SConscript
+++ b/openstack/SConscript
@@ -88,6 +88,7 @@ else:
             os.path.join('#','inc'),
             # kernel
             os.path.join('#','kernel'),
+            os.path.join('#','kernel', 'openos'),
             # drivers
             os.path.join('#','drivers','common'),
             os.path.join('#','drivers','common','crypto'),

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -64,6 +64,7 @@ buildEnv.Append(
         os.path.join('#','build','python_gcc','drivers','common','crypto'),
         # kernel
         os.path.join('#','build','python_gcc','kernel'),
+        os.path.join('#','build','python_gcc','kernel', 'openos'),
         # openstack
         os.path.join('#','build','python_gcc','openstack'),
         os.path.join('#','build','python_gcc','openstack','02a-MAClow'),
@@ -947,6 +948,7 @@ headerFiles = [
     'ccms',
     #=== libkernel
     'scheduler',
+    'scheduler_types',
     #=== libopenstack
     'openstack',
     # 02a-MAClow


### PR DESCRIPTION
This PR adds a `scheduler_types.h` header to allow custom definitions for `scheduler_vars_t` and `scheduler_dbg_t`. This way it is easy to implement the scheduler with an `RTOS` by simply implementing `scheduler.h` and having specific definitions for  `scheduler_vars_t` and `scheduler_dbg_t` based on the implementation.

See: https://github.com/RIOT-OS/RIOT/pull/14905 for an examples