### PR TITLE
kernel/scheduler: cleanups, optional debug vars

### DIFF
--- a/bsp/boards/python/openwsnmodule.c
+++ b/bsp/boards/python/openwsnmodule.c
@@ -69,7 +69,9 @@ static PyObject* OpenMote_getState(OpenMote* self) {
    PyObject* random_vars;
    PyObject* openserial_vars;
    PyObject* scheduler_vars;
+#if SCHEDULER_DEBUG_ENABLE
    PyObject* scheduler_dbg;
+#endif
    
    returnVal = PyDict_New();
    
@@ -181,10 +183,11 @@ static PyObject* OpenMote_getState(OpenMote* self) {
    PyDict_SetItemString(returnVal, "scheduler_vars", scheduler_vars);
    
    // scheduler_dbg
+#if SCHEDULER_DEBUG_ENABLE
    scheduler_dbg = PyDict_New();
    // TODO
    PyDict_SetItemString(returnVal, "scheduler_dbg", scheduler_dbg);
-   
+#endif
    return returnVal;
 }
 

--- a/bsp/boards/python/openwsnmodule_obj.h
+++ b/bsp/boards/python/openwsnmodule_obj.h
@@ -230,7 +230,9 @@ struct OpenMote {
     openserial_vars_t openserial_vars;
     // kernel
     scheduler_vars_t scheduler_vars;
+#if SCHEDULER_DEBUG_ENABLE
     scheduler_dbg_t scheduler_dbg;
+#endif
     //===== openapps
     //
     coap_vars_t coap_vars;

--- a/inc/config.h
+++ b/inc/config.h
@@ -408,6 +408,17 @@
 #define BOARD_FASTSIM_ENABLED (0)
 #endif
 
+// ======================== Kernel configuration ========================
+
+/**
+ * \def SCHEDULER_DEBUG_ENABLE
+ *
+ * Enables storing of scheduler debug variables (scheduler_debug_vars)
+ *
+ */
+#ifndef SCHEDULER_DEBUG_ENABLE
+#define SCHEDULER_DEBUG_ENABLE (0)
+#endif
 
 #include "check_config.h"
 

--- a/kernel/openos/scheduler.c
+++ b/kernel/openos/scheduler.c
@@ -13,7 +13,10 @@
 //=========================== variables =======================================
 
 scheduler_vars_t scheduler_vars;
-scheduler_dbg_t  scheduler_dbg;
+
+#if SCHEDULER_DEBUG_ENABLE
+scheduler_dbg_t scheduler_dbg;
+#endif
 
 //=========================== prototypes ======================================
 
@@ -25,7 +28,9 @@ void scheduler_init(void) {
 
     // initialization module variables
     memset(&scheduler_vars,0,sizeof(scheduler_vars_t));
+#if SCHEDULER_DEBUG_ENABLE
     memset(&scheduler_dbg,0,sizeof(scheduler_dbg_t));
+#endif
 
     // enable the scheduler's interrupt so SW can wake up the scheduler
     SCHEDULER_ENABLE_INTERRUPT();
@@ -55,7 +60,9 @@ void scheduler_start(void) {
          pThisTask->cb            = NULL;
          pThisTask->prio          = TASKPRIO_NONE;
          pThisTask->next          = NULL;
+#if SCHEDULER_DEBUG_ENABLE
          scheduler_dbg.numTasksCur--;
+#endif
       }
       debugpins_task_clr();
       board_sleep();
@@ -99,12 +106,26 @@ void scheduler_push_task(task_cbt cb, task_prio_t prio) {
     taskContainer->next            = *taskListWalker;
     *taskListWalker                = taskContainer;
     // maintain debug stats
+#if SCHEDULER_DEBUG_ENABLE
     scheduler_dbg.numTasksCur++;
     if (scheduler_dbg.numTasksCur>scheduler_dbg.numTasksMax) {
         scheduler_dbg.numTasksMax   = scheduler_dbg.numTasksCur;
     }
+#endif
 
     ENABLE_INTERRUPTS();
 }
 
+
+#if SCHEDULER_DEBUG_ENABLE
+uint8_t scheduler_debug_get_TasksCur(void)
+{
+   return scheduler_dbg.numTasksCur;
+}
+
+uint8_t scheduler_debug_get_TasksMax(void)
+{
+   return scheduler_dbg.numTasksMax;
+}
+#endif
 //=========================== private =========================================

--- a/kernel/openos/scheduler_types.h
+++ b/kernel/openos/scheduler_types.h
@@ -19,14 +19,14 @@ typedef struct task_llist_t {
 typedef struct {
    taskList_item_t                taskBuf[TASK_LIST_DEPTH];
    taskList_item_t*               task_list;
-   uint8_t                        numTasksCur;
-   uint8_t                        numTasksMax;
 } scheduler_vars_t;
 
+#if SCHEDULER_DEBUG_ENABLE
 typedef struct {
    uint8_t                        numTasksCur;
    uint8_t                        numTasksMax;
 } scheduler_dbg_t;
+#endif
 
 /**
 \}

--- a/kernel/scheduler.h
+++ b/kernel/scheduler.h
@@ -50,6 +50,11 @@ void scheduler_init(void);
 void scheduler_start(void);
 void scheduler_push_task(task_cbt task_cb, task_prio_t prio);
 
+#if SCHEDULER_DEBUG_ENABLE
+uint8_t scheduler_debug_get_TasksCur(void);
+uint8_t scheduler_debug_get_TasksMax(void);
+#endif
+
 #include "scheduler_types.h"
 
 /**


### PR DESCRIPTION
This PR adds a configuration to enable scheduler debug variables `SCHEDULER_DEBUG_ENABLE` (current and peak tasks). Disabling it will save a couple of bytes in memory.

This PR also adds geters for those variables to avoid reading them through `scheduler_dbg_t`

`numTasksCur` and `numTasksMax` are removed from `scheduler_vars_t` since there was no use of them.