### PR TITLE
openstack: add mac interfaces

### DIFF
--- a/openstack/02a-MAClow/IEEE802154E.c
+++ b/openstack/02a-MAClow/IEEE802154E.c
@@ -844,10 +844,6 @@ port_INLINE void activity_synchronize_endOfFrame(PORT_TIMER_WIDTH capturedTime) 
 
         // declare synchronized
         changeIsSync(TRUE);
-        // log the info
-        LOG_SUCCESS(COMPONENT_IEEE802154E, ERR_SYNCHRONIZED,
-                (errorparameter_t) ieee154e_vars.slotOffset,
-                (errorparameter_t) 0);
 
         // send received EB up the stack so RES can update statistics (synchronizing)
         notif_receive(ieee154e_vars.dataReceived);
@@ -925,11 +921,6 @@ port_INLINE void activity_ti1ORri1(void) {
 
             // declare myself desynchronized
             changeIsSync(FALSE);
-
-            // log the error
-            LOG_ERROR(COMPONENT_IEEE802154E, ERR_DESYNCHRONIZED,
-                      (errorparameter_t)ieee154e_vars.slotOffset,
-                      (errorparameter_t)0);
 
             // update the statistics
             ieee154e_stats.numDeSync++;
@@ -2665,9 +2656,26 @@ void synchronizeAck(PORT_SIGNED_INT_WIDTH timeCorrection) {
 #endif
 }
 
+void __attribute__((weak)) ieee154e_indicate_sync(bool isSync)
+{
+    if(isSync) {
+        // log the info
+        LOG_SUCCESS(COMPONENT_IEEE802154E, ERR_SYNCHRONIZED,
+                (errorparameter_t) ieee154e_vars.slotOffset,
+                (errorparameter_t) 0);
+    }
+    else {
+        // log the error
+        LOG_ERROR(COMPONENT_IEEE802154E, ERR_DESYNCHRONIZED,
+                    (errorparameter_t)ieee154e_vars.slotOffset,
+                    (errorparameter_t)0);
+
+    }
+}
+
 void changeIsSync(bool newIsSync) {
     ieee154e_vars.isSync = newIsSync;
-
+    ieee154e_indicate_sync(newIsSync);
     if (ieee154e_vars.isSync == TRUE) {
         leds_sync_on();
         resetStats();

--- a/openstack/02a-MAClow/IEEE802154E.h
+++ b/openstack/02a-MAClow/IEEE802154E.h
@@ -348,6 +348,9 @@ void ieee154e_startOfFrame(PORT_TIMER_WIDTH capturedTime);
 
 void ieee154e_endOfFrame(PORT_TIMER_WIDTH capturedTime);
 
+// weak declaration
+void ieee154e_indicate_sync(bool isSync);
+
 // misc
 bool debugPrint_asn(void);
 

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -1066,6 +1066,23 @@ port_INLINE bool sixtop_processIEs(OpenQueueEntry_t* pkt, uint16_t* lenIE) {
     return TRUE;
 }
 
+void __attribute__((weak)) sixtop_indicate_recv(uint8_t code)
+{
+    if (code == IANA_6TOP_RC_SUCCESS) {
+        LOG_SUCCESS(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
+                    (errorparameter_t) code,
+                    (errorparameter_t) sixtop_vars.six2six_state);
+    } else if (code == IANA_6TOP_RC_EOL || code == IANA_6TOP_RC_BUSY || code == IANA_6TOP_RC_LOCKED) {
+        LOG_INFO(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
+                (errorparameter_t) code,
+                (errorparameter_t) sixtop_vars.six2six_state);
+    } else {
+        LOG_ERROR(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
+                (errorparameter_t) code,
+                (errorparameter_t) sixtop_vars.six2six_state);
+    }
+}
+
 void sixtop_six2six_notifyReceive(
         uint8_t version,
         uint8_t type,
@@ -1578,21 +1595,7 @@ void sixtop_six2six_notifyReceive(
             sixtop_vars.cb_sf_handleRCError(code, &(pkt->l2_nextORpreviousHop));
         }
 
-        if (code == IANA_6TOP_RC_SUCCESS) {
-            LOG_SUCCESS(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
-                        (errorparameter_t)
-            code,
-                    (errorparameter_t)
-            sixtop_vars.six2six_state);
-        } else if (code == IANA_6TOP_RC_EOL || code == IANA_6TOP_RC_BUSY || code == IANA_6TOP_RC_LOCKED) {
-            LOG_INFO(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
-                    (errorparameter_t) code,
-                    (errorparameter_t) sixtop_vars.six2six_state);
-        } else {
-            LOG_ERROR(COMPONENT_SIXTOP, ERR_SIXTOP_RETURNCODE,
-                    (errorparameter_t) code,
-                    (errorparameter_t) sixtop_vars.six2six_state);
-        }
+        sixtop_indicate_recv(code);
 
         memset(&sixtop_vars.neighborToClearCells, 0, sizeof(open_addr_t));
         sixtop_vars.six2six_state = SIX_STATE_IDLE;

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -438,11 +438,7 @@ void task_sixtopNotifSendDone(void) {
             break;
         default:
             // send the rest up the stack
-#if OPENWSN_6LO_FRAGMENTATION_C
-            frag_sendDone(msg, msg->l2_sendDoneError);
-#else
-            iphc_sendDone(msg, msg->l2_sendDoneError);
-#endif
+            upper_sendDone(msg, msg->l2_sendDoneError);
             break;
     }
 }
@@ -502,11 +498,7 @@ void task_sixtopNotifReceive(void) {
                     break;
                 }
                 // send to upper layer
-#if OPENWSN_6LO_FRAGMENTATION_C
-                frag_receive(msg);
-#else
-                iphc_receive(msg);
-#endif
+                upper_receive(msg);
             } else {
                 // free up the RAM
                 openqueue_freePacketBuffer(msg);

--- a/openstack/02b-MAChigh/sixtop.h
+++ b/openstack/02b-MAChigh/sixtop.h
@@ -147,6 +147,10 @@ owerror_t sixtop_request(
 // from upper layer
 owerror_t sixtop_send(OpenQueueEntry_t *msg);
 
+// to upper layer
+void upper_sendDone(OpenQueueEntry_t *msg, owerror_t error);
+void upper_receive(OpenQueueEntry_t *msg);
+
 // from lower layer
 void task_sixtopNotifSendDone(void);
 
@@ -163,5 +167,3 @@ bool debugPrint_kaPeriod(void);
 */
 
 #endif /* OPENWSN_SIXTOP_H */
-
-

--- a/openstack/02b-MAChigh/sixtop.h
+++ b/openstack/02b-MAChigh/sixtop.h
@@ -151,6 +151,8 @@ owerror_t sixtop_send(OpenQueueEntry_t *msg);
 void upper_sendDone(OpenQueueEntry_t *msg, owerror_t error);
 void upper_receive(OpenQueueEntry_t *msg);
 
+void sixtop_indicate_recv(uint8_t code);
+
 // from lower layer
 void task_sixtopNotifSendDone(void);
 

--- a/openstack/03a-IPHC/iphc.c
+++ b/openstack/03a-IPHC/iphc.c
@@ -46,6 +46,18 @@ uint8_t iphc_getAsnLen(uint8_t* asn);
 
 //=========================== public ==========================================
 
+#if !OPENWSN_6LO_FRAGMENTATION_C
+void upper_sendDone(OpenQueueEntry_t *msg, owerror_t error)
+{
+    iphc_sendDone(msg, error);
+}
+
+void upper_receive(OpenQueueEntry_t *msg)
+{
+    iphc_receive(msg);
+}
+#endif
+
 void iphc_init(void) {
 }
 


### PR DESCRIPTION
This PR adds some functions to allow interacting directly with the mac layer or getting notified from mac layer events:

- Added `upper_sendDone/receive` to handle those events in an arbitrary higher layer.
- Added `ieee154e_indicate_sync()` function that default to `openserial` logs but that can be overridden by a higher layer to
  do some more meaningful stuff or just log in a different format.
- Added `sixtop_indicate_recv()` function to be able to notify a higher layer of a sixtop request outcome.