### PR TITLE
Fix linker issue IoT-Lab_M3 and IoT-Lab-A8_M3

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -455,6 +455,8 @@ elif env['toolchain'] == 'armgcc':
         env.Append(LINKFLAGS='-mthumb')
         env.Append(LINKFLAGS='-mthumb-interwork')
         env.Append(LINKFLAGS='-nostartfiles')
+        env.Append(LINKFLAGS='-specs=nosys.specs')
+        env.Append(LINKFLAGS='-specs=nano.specs')
         env.Append(LINKFLAGS='-Tbsp/boards/' + env['board'] + '/stm32_flash.ld')
         env.Append(
             LINKFLAGS=os.path.join('build', env['board'] + '_armgcc', 'bsp', 'boards', env['board'], 'startup.o'))

--- a/bsp/boards/iot-lab_A8-M3/stm32_flash.ld
+++ b/bsp/boards/iot-lab_A8-M3/stm32_flash.ld
@@ -15,7 +15,7 @@
 **
 **  Environment : Atollic TrueSTUDIO(R)
 **
-**  Distribution: The file is distributed “as is,” without any warranty
+**  Distribution: The file is distributed as is, without any warranty
 **                of any kind.
 **
 **  (c)Copyright Atollic AB.
@@ -88,12 +88,14 @@ SECTIONS
 
   .preinit_array     :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
   .init_array :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
@@ -101,6 +103,7 @@ SECTIONS
   } >FLASH
   .fini_array :
   {
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(.fini_array*))
     KEEP (*(SORT(.fini_array.*)))
@@ -145,13 +148,12 @@ SECTIONS
 	{
 		PROVIDE(__heap1_start = .);
 		. = . + __heap1_size;
-		PROVIDE(__heap1_max = .);	
-	} > RAM	
+		PROVIDE(__heap1_max = .);
+	} > RAM
 
-  /*
   PROVIDE ( end = _ebss );
   PROVIDE ( _end = _ebss );
-  */
+
   /* User_heap_stack section, used to check that there is enough RAM left */
   /*
   ._user_heap_stack :

--- a/bsp/boards/iot-lab_M3/stm32_flash.ld
+++ b/bsp/boards/iot-lab_M3/stm32_flash.ld
@@ -15,7 +15,7 @@
 **
 **  Environment : Atollic TrueSTUDIO(R)
 **
-**  Distribution: The file is distributed �as is,� without any warranty
+**  Distribution: The file is distributed as is, without any warranty
 **                of any kind.
 **
 **  (c)Copyright Atollic AB.
@@ -151,10 +151,9 @@ SECTIONS
 		PROVIDE(__heap1_max = .);
 	} > RAM
 
-  /*
   PROVIDE ( end = _ebss );
   PROVIDE ( _end = _ebss );
-  */
+
   /* User_heap_stack section, used to check that there is enough RAM left */
   /*
   ._user_heap_stack :


### PR DESCRIPTION
This PR resolves an issue where the linker would fail when the `boardopt=printf` was specified. The `printf` option relies on `stdarg.h` which requires specific linker flags.