### PR TITLE
coap: Wrappers to adapt to the new API.

### DIFF
--- a/openstack/03b-IPv6/forwarding.c
+++ b/openstack/03b-IPv6/forwarding.c
@@ -463,7 +463,7 @@ owerror_t forwarding_send_internal_RoutingTable(
     open_addr_t temp_prefix64btoWrite;
 
     // retrieve the next hop from the routing table
-    if (msg->is_cjoin_response || msg->creator == COMPONENT_CJOIN) {
+    if (packetfunctions_isLinkLocal(&msg->l3_destinationAdd)) {
         if (neighbors_isStableNeighbor(&(msg->l3_destinationAdd)) || msg->is_cjoin_response) {
             // IP destination is 1-hop neighbor, send directly
             packetfunctions_ip128bToMac64b(&(msg->l3_destinationAdd), &temp_prefix64btoWrite,

--- a/openweb/opencoap/coap.c
+++ b/openweb/opencoap/coap.c
@@ -454,6 +454,8 @@ void coap_receive(OpenQueueEntry_t *msg) {
         }
 
     } else {
+	// resource not found but success in creating the response
+        outcome = E_SUCCESS;
         // reset packet payload (DO NOT DELETE, we will reuse same buffer for response)
         msg->payload = &(msg->packet[127]); // FIXME use packetfunctions to reset
         msg->length = 0;

--- a/openweb/opencoap/coap.c
+++ b/openweb/opencoap/coap.c
@@ -968,6 +968,9 @@ void coap_sock_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg) {
             return;
         }
 
+	// take ownership over the packet
+	msg->owner = COMPONENT_OPENCOAP;
+
 	if (packetfunctions_reserveHeader(&msg, COAP_MAX_MSG_LEN) == E_FAIL) {
             openserial_printf("Could not reserve header\n");
             return;

--- a/openweb/opencoap/coap.c
+++ b/openweb/opencoap/coap.c
@@ -21,6 +21,11 @@
 coap_vars_t coap_vars;
 
 //=========================== prototype =======================================
+
+void coap_receive(OpenQueueEntry_t *msg);
+
+void coap_sendDone(OpenQueueEntry_t *msg, owerror_t error);
+
 owerror_t coap_header_encode(OpenQueueEntry_t *msg,
                              uint8_t version,
                              coap_type_t type,

--- a/openweb/opencoap/coap.h
+++ b/openweb/opencoap/coap.h
@@ -226,10 +226,6 @@ typedef struct {
 // from stack
 void coap_init(void);
 
-void coap_receive(OpenQueueEntry_t *msg);
-
-void coap_sendDone(OpenQueueEntry_t *msg, owerror_t error);
-
 // from CoAP resources
 void coap_writeLinks(OpenQueueEntry_t *msg, uint8_t componentID);
 
@@ -245,7 +241,7 @@ owerror_t coap_send(
         coap_resource_desc_t *descSender
 );
 
-// option handling
+// option handling for OSCORE
 coap_option_class_t coap_get_option_class(coap_option_t type);
 
 uint8_t coap_options_encode(OpenQueueEntry_t *msg,

--- a/openweb/opencoap/coap.h
+++ b/openweb/opencoap/coap.h
@@ -9,7 +9,6 @@
 */
 
 #include "config.h"
-#include "opentimers.h"
 #include "sock.h"
 #include "async.h"
 

--- a/openweb/opencoap/coap.h
+++ b/openweb/opencoap/coap.h
@@ -10,7 +10,6 @@
 
 #include "config.h"
 #include "opentimers.h"
-#include "udp.h"
 #include "sock.h"
 #include "async.h"
 
@@ -36,6 +35,8 @@ static const uint8_t ipAddr_ringmaster[] = {0xbb, 0xbb, 0x00, 0x00, 0x00, 0x00, 
 
 // This value may be reduced as a memory optimization, but would invalidate spec compliance
 #define COAP_MAX_TKL                   8
+
+#define COAP_MAX_MSG_LEN               IPV6_PACKET_SIZE - 20
 
 #define COAP_PAYLOAD_MARKER            0xFF
 

--- a/openweb/opencoap/coap.h
+++ b/openweb/opencoap/coap.h
@@ -11,6 +11,8 @@
 #include "config.h"
 #include "opentimers.h"
 #include "udp.h"
+#include "sock.h"
+#include "async.h"
 
 //=========================== define ==========================================
 
@@ -215,6 +217,7 @@ typedef struct {
     uint8_t delayCounter;
     uint16_t messageID;
     coap_statelessproxy_vars_t statelessProxy;
+    sock_udp_t sock;
 } coap_vars_t;
 
 //=========================== prototypes ======================================

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -844,6 +844,7 @@ functions_to_change = [
     'coap_handle_stateless_proxy',
     'coap_add_stateless_proxy_option',
     'coap_forward_message',
+    'coap_sock_handler',
     'icmpv6coap_timer_cb',
     # oscore
     'oscore_init_security_context',

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -845,6 +845,7 @@ functions_to_change = [
     'coap_add_stateless_proxy_option',
     'coap_forward_message',
     'coap_sock_handler',
+    'coap_sock_send_internal',
     'icmpv6coap_timer_cb',
     # oscore
     'oscore_init_security_context',


### PR DESCRIPTION
The PR adds two `opencoap` wrapper functions, one for send and one for receive, to adapt the code to the new sock API.