### PR TITLE
openapps/cjoin: add missing opentimers include

### DIFF
--- a/openapps/cjoin/cjoin.h
+++ b/openapps/cjoin/cjoin.h
@@ -9,6 +9,7 @@
 */
 
 #include "opendefs.h"
+#include "opentimers.h"
 #include "coap.h"
 #include "oscore.h"
 //=========================== define ==========================================


### PR DESCRIPTION
Opentimer types are used in the defintion of `cjoin_vars_t` but the include is missing, this PR fixes this.