### PR TITLE
inc/config: use channel hopping by default

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -341,7 +341,7 @@
  *
  */
 #ifndef IEEE802154E_SINGLE_CHANNEL
-#define IEEE802154E_SINGLE_CHANNEL      11
+#define IEEE802154E_SINGLE_CHANNEL      0
 #endif
 
 /**


### PR DESCRIPTION
Not sure what maintainers prefer here, but maybe by default channel hopping should be enabled. I think it is what someone would expect when running the default build for OpenWSN. Feel free to close this one if you disagree.