### PR TITLE
inc/config: add option to switch off leds

### DIFF
--- a/bsp/boards/openmote-b-24ghz/leds.c
+++ b/bsp/boards/openmote-b-24ghz/leds.c
@@ -40,8 +40,10 @@ void bspLedToggle(uint8_t ui8Leds);
 //=========================== public ==========================================
 
 void leds_init(void) {
+#if BOARD_LEDS
     GPIOPinTypeGPIOOutput(BSP_LED_BASE, BSP_LED_ALL);
     GPIOPinWrite(BSP_LED_BASE, BSP_LED_ALL, BSP_LED_ALL);
+#endif
 }
 
 // red
@@ -55,8 +57,10 @@ void    leds_error_toggle(void) {
     bspLedToggle(BSP_LED_1);
 }
 uint8_t leds_error_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_1);
     return (uint8_t)(ui32Toggle & BSP_LED_1)>>4;
+#endif
 }
 
 // green
@@ -70,23 +74,30 @@ void    leds_sync_toggle(void) {
     bspLedToggle(BSP_LED_4);
 }
 uint8_t leds_sync_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
     return (uint8_t)(ui32Toggle & BSP_LED_4)>>5;
+#endif
 }
 
 // orange
 void    leds_radio_on(void) {
+
     bspLedSet(BSP_LED_2);
 }
 void    leds_radio_off(void) {
+
     bspLedClear(BSP_LED_2);
 }
 void    leds_radio_toggle(void) {
+
     bspLedToggle(BSP_LED_2);
 }
 uint8_t leds_radio_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
     return (uint8_t)(ui32Toggle & BSP_LED_2)>>7;
+#endif
 }
 
 // yellow
@@ -100,8 +111,10 @@ void    leds_debug_toggle(void) {
     bspLedToggle(BSP_LED_3);
 }
 uint8_t leds_debug_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_3);
     return (uint8_t)(ui32Toggle & BSP_LED_3)>>6;
+#endif
 }
 
 // all
@@ -116,6 +129,7 @@ void leds_all_toggle(void) {
 }
 
 void leds_error_blink(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -128,9 +142,11 @@ void leds_error_blink(void) {
         for (delay=0xffff;delay>0;delay--);
         for (delay=0xffff;delay>0;delay--);
     }
+#endif
 }
 
 void leds_circular_shift(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -140,7 +156,7 @@ void leds_circular_shift(void) {
     // incrementally turn LED on
     for (i=0;i<10;i++) {
         bspLedSet(BSP_LED_1);
-        for (delay=0xffff;delay>0;delay--)
+        for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_1);
         bspLedSet(BSP_LED_2);
         for (delay=0xffff;delay>0;delay--);
@@ -152,9 +168,11 @@ void leds_circular_shift(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
    }
+#endif
 }
 
 void leds_increment(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -173,25 +191,31 @@ void leds_increment(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
     }
+#endif
 }
 
 //=========================== private =========================================
 
 port_INLINE void bspLedSet(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn on specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, 0);
+#endif
 }
 
 port_INLINE void bspLedClear(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn off specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui8Leds);
+#endif
 }
 
 port_INLINE void bspLedToggle(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Get current pin values of selected bits
     //
@@ -206,4 +230,5 @@ port_INLINE void bspLedToggle(uint8_t ui8Leds){
     // Set GPIO
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui32Toggle);
+#endif
 }

--- a/bsp/boards/openmote-b-subghz/leds.c
+++ b/bsp/boards/openmote-b-subghz/leds.c
@@ -40,8 +40,10 @@ void bspLedToggle(uint8_t ui8Leds);
 //=========================== public ==========================================
 
 void leds_init(void) {
+#if BOARD_LEDS
     GPIOPinTypeGPIOOutput(BSP_LED_BASE, BSP_LED_ALL);
     GPIOPinWrite(BSP_LED_BASE, BSP_LED_ALL, BSP_LED_ALL);
+#endif
 }
 
 // red
@@ -55,8 +57,10 @@ void    leds_error_toggle(void) {
     bspLedToggle(BSP_LED_1);
 }
 uint8_t leds_error_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_1);
     return (uint8_t)(ui32Toggle & BSP_LED_1)>>4;
+#endif
 }
 
 // green
@@ -70,23 +74,30 @@ void    leds_sync_toggle(void) {
     bspLedToggle(BSP_LED_4);
 }
 uint8_t leds_sync_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
     return (uint8_t)(ui32Toggle & BSP_LED_4)>>5;
+#endif
 }
 
 // orange
 void    leds_radio_on(void) {
+
     bspLedSet(BSP_LED_2);
 }
 void    leds_radio_off(void) {
+
     bspLedClear(BSP_LED_2);
 }
 void    leds_radio_toggle(void) {
+
     bspLedToggle(BSP_LED_2);
 }
 uint8_t leds_radio_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
     return (uint8_t)(ui32Toggle & BSP_LED_2)>>7;
+#endif
 }
 
 // yellow
@@ -100,8 +111,10 @@ void    leds_debug_toggle(void) {
     bspLedToggle(BSP_LED_3);
 }
 uint8_t leds_debug_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_3);
     return (uint8_t)(ui32Toggle & BSP_LED_3)>>6;
+#endif
 }
 
 // all
@@ -116,6 +129,7 @@ void leds_all_toggle(void) {
 }
 
 void leds_error_blink(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -128,9 +142,11 @@ void leds_error_blink(void) {
         for (delay=0xffff;delay>0;delay--);
         for (delay=0xffff;delay>0;delay--);
     }
+#endif
 }
 
 void leds_circular_shift(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -140,7 +156,7 @@ void leds_circular_shift(void) {
     // incrementally turn LED on
     for (i=0;i<10;i++) {
         bspLedSet(BSP_LED_1);
-        for (delay=0xffff;delay>0;delay--)
+        for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_1);
         bspLedSet(BSP_LED_2);
         for (delay=0xffff;delay>0;delay--);
@@ -152,9 +168,11 @@ void leds_circular_shift(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
    }
+#endif
 }
 
 void leds_increment(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -173,25 +191,31 @@ void leds_increment(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
     }
+#endif
 }
 
 //=========================== private =========================================
 
 port_INLINE void bspLedSet(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn on specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, 0);
+#endif
 }
 
 port_INLINE void bspLedClear(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn off specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui8Leds);
+#endif
 }
 
 port_INLINE void bspLedToggle(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Get current pin values of selected bits
     //
@@ -206,4 +230,5 @@ port_INLINE void bspLedToggle(uint8_t ui8Leds){
     // Set GPIO
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui32Toggle);
+#endif
 }

--- a/bsp/boards/openmote-b/leds.c
+++ b/bsp/boards/openmote-b/leds.c
@@ -40,8 +40,10 @@ void bspLedToggle(uint8_t ui8Leds);
 //=========================== public ==========================================
 
 void leds_init(void) {
+#if BOARD_LEDS
     GPIOPinTypeGPIOOutput(BSP_LED_BASE, BSP_LED_ALL);
     GPIOPinWrite(BSP_LED_BASE, BSP_LED_ALL, BSP_LED_ALL);
+#endif
 }
 
 // red
@@ -55,11 +57,13 @@ void    leds_error_toggle(void) {
     bspLedToggle(BSP_LED_1);
 }
 uint8_t leds_error_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_1);
     return (uint8_t)(ui32Toggle & BSP_LED_1)>>4;
+#endif
 }
 
-// orange
+// green
 void    leds_sync_on(void) {
     bspLedSet(BSP_LED_2);
 }
@@ -70,23 +74,30 @@ void    leds_sync_toggle(void) {
     bspLedToggle(BSP_LED_2);
 }
 uint8_t leds_sync_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
     return (uint8_t)(ui32Toggle & BSP_LED_2)>>5;
+#endif
 }
 
-// green
+// orange
 void    leds_radio_on(void) {
-    bspLedSet(BSP_LED_4);
+
+    bspLedSet(BSP_LED_2);
 }
 void    leds_radio_off(void) {
-    bspLedClear(BSP_LED_4);
+
+    bspLedClear(BSP_LED_2);
 }
 void    leds_radio_toggle(void) {
-    bspLedToggle(BSP_LED_4);
+
+    bspLedToggle(BSP_LED_2);
 }
 uint8_t leds_radio_isOn(void) {
-    uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_4);
-    return (uint8_t)(ui32Toggle & BSP_LED_4)>>7;
+#if BOARD_LEDS
+    uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_2);
+    return (uint8_t)(ui32Toggle & BSP_LED_2)>>7;
+#endif
 }
 
 // yellow
@@ -100,8 +111,10 @@ void    leds_debug_toggle(void) {
     bspLedToggle(BSP_LED_3);
 }
 uint8_t leds_debug_isOn(void) {
+#if BOARD_LEDS
     uint32_t ui32Toggle = GPIOPinRead(BSP_LED_BASE, BSP_LED_3);
     return (uint8_t)(ui32Toggle & BSP_LED_3)>>6;
+#endif
 }
 
 // all
@@ -116,6 +129,7 @@ void leds_all_toggle(void) {
 }
 
 void leds_error_blink(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -128,9 +142,11 @@ void leds_error_blink(void) {
         for (delay=0xffff;delay>0;delay--);
         for (delay=0xffff;delay>0;delay--);
     }
+#endif
 }
 
 void leds_circular_shift(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -152,9 +168,11 @@ void leds_circular_shift(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
    }
+#endif
 }
 
 void leds_increment(void) {
+#if BOARD_LEDS
     uint8_t i;
     volatile uint16_t delay;
 
@@ -173,25 +191,31 @@ void leds_increment(void) {
         for (delay=0xffff;delay>0;delay--);
         bspLedClear(BSP_LED_ALL);
     }
+#endif
 }
 
 //=========================== private =========================================
 
 port_INLINE void bspLedSet(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn on specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, 0);
+#endif
 }
 
 port_INLINE void bspLedClear(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Turn off specified LEDs
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui8Leds);
+#endif
 }
 
 port_INLINE void bspLedToggle(uint8_t ui8Leds){
+#if BOARD_LEDS
     //
     // Get current pin values of selected bits
     //
@@ -206,4 +230,5 @@ port_INLINE void bspLedToggle(uint8_t ui8Leds){
     // Set GPIO
     //
     GPIOPinWrite(BSP_LED_BASE, ui8Leds, ui32Toggle);
+#endif
 }

--- a/inc/check_config.h
+++ b/inc/check_config.h
@@ -52,6 +52,14 @@
 #error 'Hardware encryption not supported on this platform.'
 #endif
 
+#if !BOARD_LEDS && (\
+    !defined(OPENMOTE_CC2538) || \
+    defined(OPENMOTE_B) || \
+    defined(OPENMOTE_B_24GHZ) || \
+    defined(OPENMOTE_B_SUBGHZ))
+#error 'Disabling Leds is not supported by this platform.'
+#endif
+
 #if OPENWSN_IEEE802154E_SECURITY_C && !OPENWSN_CJOIN_C
 #error 'Link-layer security requires CJOIN application.'
 #endif

--- a/inc/config.h
+++ b/inc/config.h
@@ -422,6 +422,17 @@
 #endif
 
 /**
+ * \def BOARD_LEDS
+ *
+ * Turn on leds
+ *
+ */
+#ifndef BOARD_LEDS
+#define BOARD_LEDS (1)
+#endif
+
+
+/**
  * \def BOARD_FASTSIM_ENABLED
  *
  * Enables fast UART printing in simulation mode. Active by default.


### PR DESCRIPTION
This PR wants to allow not switching on the leds to allow more accurate power measurements. Only `openmote-%` boards
are currently supported, therefore a check is added.