### PR TITLE
inc/opendefs: add new neighbors logging

### DIFF
--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -234,11 +234,12 @@ enum {
    // l2b
    ERR_SCHEDULE_ADD_DUPLICATE_SLOT     = 0x20, // the slot {0} to be added is already in schedule
    ERR_NEIGHBORS_FULL                  = 0x21, // neighbors table is full (max number of neighbor is {0})
+
    ERR_NO_SENT_PACKET                  = 0x22, // there is no sent packet in queue
    ERR_NO_RECEIVED_PACKET              = 0x23, // there is no received packet in queue
    ERR_SCHEDULE_OVERFLOWN              = 0x24, // schedule overflown
    ERR_SIXTOP_RETURNCODE               = 0x25, // sixtop return code {0} at sixtop state {1}
-   ERR_SIXTOP_REQUEST                  = 0x26, // sending a 6top request
+   ERR_SIXTOP_REQUEST                  = 0x26, // sending a 6top request {0}
    ERR_SIXTOP_COUNT                    = 0x27, // there are {0} cells to request mote
    ERR_SIXTOP_LIST                     = 0x28, // the cells reserved to request mote contains slot {0} and slot {1}
    ERR_UNSUPPORTED_FORMAT              = 0x29, // the received packet format is not supported (code location {0})

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -234,7 +234,6 @@ enum {
    // l2b
    ERR_SCHEDULE_ADD_DUPLICATE_SLOT     = 0x20, // the slot {0} to be added is already in schedule
    ERR_NEIGHBORS_FULL                  = 0x21, // neighbors table is full (max number of neighbor is {0})
-
    ERR_NO_SENT_PACKET                  = 0x22, // there is no sent packet in queue
    ERR_NO_RECEIVED_PACKET              = 0x23, // there is no received packet in queue
    ERR_SCHEDULE_OVERFLOWN              = 0x24, // schedule overflown
@@ -290,6 +289,7 @@ enum {
    ERR_INVALID_PARAM                   = 0x53, // received an invalid parameter
    ERR_COPY_TO_SPKT                    = 0x54, // copy packet content to small packet (pkt len {} < max len {})
    ERR_COPY_TO_BPKT                    = 0x55, // copy packet content to big packet (pkt len {} > max len {})
+   ERR_NEW_NEIGHBOR                    = 0x56, // New neighbor {1:04x} with RSSI {0},
 };
 
 //=========================== typedef =========================================

--- a/openstack/02b-MAChigh/neighbors.c
+++ b/openstack/02b-MAChigh/neighbors.c
@@ -7,6 +7,7 @@
 #include "IEEE802154E.h"
 #include "openrandom.h"
 #include "msf.h"
+#include "openserial.h"
 
 //=========================== variables =======================================
 
@@ -665,6 +666,8 @@ void registerNewNeighbor(open_addr_t *address,
                          uint8_t joinPrio,
                          bool insecure) {
     uint8_t i;
+    open_addr_t addr_16;
+    uint16_t short_addr;
 
     // filter errors
     if (address->type != ADDR_64B) {
@@ -681,6 +684,13 @@ void registerNewNeighbor(open_addr_t *address,
                 if (rssi < GOODNEIGHBORMINRSSI) {
                     break;
                 }
+                addr_16.type = ADDR_16B;
+                packetfunctions_mac64bToMac16b(address, &addr_16);
+                short_addr = ((addr_16.addr_16b[0] << 8) & 0xff00) |
+                             (addr_16.addr_16b[1] & 0x00ff);
+                LOG_VERBOSE(COMPONENT_NEIGHBORS, ERR_NEW_NEIGHBOR,
+                    (errorparameter_t) rssi,
+                    (errorparameter_t) short_addr);
                 // add this neighbor
                 neighbors_vars.neighbors[i].used = TRUE;
                 neighbors_vars.neighbors[i].insecure = insecure;


### PR DESCRIPTION
This PR adds some information about the new neighbor RSSI, it was useful for me to realize that
nodes at the same distance where hearing the same nodes with a huge RSSI penalty.