### PR TITLE
bsp/board/openmote-%: add DEEP_SLEEP configuration

### DIFF
--- a/bsp/boards/openmote-b-24ghz/board.c
+++ b/bsp/boards/openmote-b-24ghz/board.c
@@ -96,20 +96,31 @@ void antenna_init(void) {
 
 void antenna_cc2538(void) {
   GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_CC2538_24GHZ, 0);
-  GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_AT215_24GHZ, BSP_ANTENNA_AT215_24GHZ);  
+  GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_AT215_24GHZ, BSP_ANTENNA_AT215_24GHZ);
 }
 
 void antenna_at86rf215(void) {
   GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_AT215_24GHZ, 0);
   GPIOPinWrite(BSP_ANTENNA_BASE, BSP_ANTENNA_CC2538_24GHZ, BSP_ANTENNA_CC2538_24GHZ);
-}  
+}
 
 /**
  * Puts the board to sleep
  */
 void board_sleep(void) {
+#if BOARD_DEEP_SLEEP
+    if(radio_is_enabled()) {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
+      SysCtrlSleep();
+    }
+    else {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_1);
+      SysCtrlDeepSleep();
+    }
+#else
     SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
     SysCtrlSleep();
+#endif
 }
 
 /**

--- a/bsp/boards/openmote-b-24ghz/radio.c
+++ b/bsp/boards/openmote-b-24ghz/radio.c
@@ -41,6 +41,7 @@ typedef struct {
    radio_capture_cbt         startFrame_cb;
    radio_capture_cbt         endFrame_cb;
    radio_state_t             state;
+   bool                      radio_txrx_enabled;
 } radio_vars_t;
 
 radio_vars_t radio_vars;
@@ -259,6 +260,7 @@ void radio_loadPacket(uint8_t* packet, uint16_t len) {
 }
 
 void radio_txEnable(void) {
+   radio_vars.radio_txrx_enabled = true;
 
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_TX;
@@ -299,7 +301,7 @@ void radio_txNow(void) {
 //===== RX
 
 void radio_rxEnable(void) {
-
+   radio_vars.radio_txrx_enabled = true;
    // change state
    radio_vars.state = RADIOSTATE_ENABLING_RX;
 
@@ -404,6 +406,7 @@ void radio_on(void){
 }
 
 void radio_off(void){
+   radio_vars.radio_txrx_enabled = false;
    /* Wait for ongoing TX to complete (e.g. this could be an outgoing ACK) */
    while(HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
    //CC2538_RF_CSP_ISFLUSHRX();
@@ -537,4 +540,8 @@ void radio_error_isr(void){
       HWREG(RFCORE_XREG_RFERRM) = ~(((0x02)<<RFCORE_XREG_RFERRM_RFERRM_S)&RFCORE_XREG_RFERRM_RFERRM_M);
       //poipoi  -- todo handle error
    }
+}
+
+bool radio_is_enabled(void) {
+   return radio_vars.radio_txrx_enabled;
 }

--- a/bsp/boards/openmote-b/board.c
+++ b/bsp/boards/openmote-b/board.c
@@ -72,7 +72,7 @@ int main(void) {
 
 void board_init(void) {
    user_button_initialized = FALSE;
-   
+
    gpio_init();
    clock_init();
    antenna_init();
@@ -104,8 +104,19 @@ void antenna_init(void) {
  * Puts the board to sleep
  */
 void board_sleep(void) {
+#if BOARD_DEEP_SLEEP
+    if(radio_is_enabled()) {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
+      SysCtrlSleep();
+    }
+    else {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_1);
+      SysCtrlDeepSleep();
+    }
+#else
     SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
     SysCtrlSleep();
+#endif
 }
 
 /**
@@ -115,7 +126,7 @@ void board_sleep(void) {
 void board_timer_init(void) {
     // Configure the timer
     TimerConfigure(GPTIMER2_BASE, GPTIMER_CFG_PERIODIC_UP);
-    
+
     // Enable the timer
     TimerEnable(GPTIMER2_BASE, GPTIMER_BOTH);
 }
@@ -126,9 +137,9 @@ void board_timer_init(void) {
  */
 uint32_t board_timer_get(void) {
     uint32_t current;
-    
+
     current = TimerValueGet(GPTIMER2_BASE, GPTIMER_A) >> 5;
-    
+
     return current;
 }
 
@@ -143,7 +154,7 @@ bool board_timer_expired(uint32_t future) {
     current = TimerValueGet(GPTIMER2_BASE, GPTIMER_A) >> 5;
 
     remaining = (int32_t) (future - current);
-    
+
     if (remaining > 0) {
         return false;
     } else {
@@ -325,7 +336,7 @@ static void GPIO_C_Handler(void) {
     FlashMainPageErase(CC2538_FLASH_ADDRESS);
 
     leds_circular_shift();
-    
+
     /* Reset the board */
     SysCtrlReset();
 }

--- a/bsp/boards/openmote-cc2538/board.c
+++ b/bsp/boards/openmote-cc2538/board.c
@@ -107,8 +107,19 @@ void board_init(void) {
  * Puts the board to sleep
  */
 void board_sleep(void) {
+#if BOARD_DEEP_SLEEP
+    if(radio_is_enabled()) {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
+      SysCtrlSleep();
+    }
+    else {
+      SysCtrlPowerModeSet(SYS_CTRL_PM_1);
+      SysCtrlDeepSleep();
+    }
+#else
     SysCtrlPowerModeSet(SYS_CTRL_PM_NOACTION);
     SysCtrlSleep();
+#endif
 }
 
 /**

--- a/bsp/boards/openmote-cc2538/radio.c
+++ b/bsp/boards/openmote-cc2538/radio.c
@@ -41,6 +41,7 @@ typedef struct {
     radio_capture_cbt startFrame_cb;
     radio_capture_cbt endFrame_cb;
     radio_state_t state;
+    bool radio_txrx_enabled;
 } radio_vars_t;
 
 radio_vars_t radio_vars;
@@ -210,7 +211,6 @@ void radio_rfOn(void) {
 }
 
 void radio_rfOff(void) {
-
     // change state
     radio_vars.state = RADIOSTATE_TURNING_OFF;
     radio_off();
@@ -221,7 +221,12 @@ void radio_rfOff(void) {
     disable_radio_interrupts();
 
     // change state
+    radio_vars.radio_txrx_enabled = false;
     radio_vars.state = RADIOSTATE_RFOFF;
+}
+
+bool radio_is_enabled(void) {
+   return radio_vars.radio_txrx_enabled;
 }
 
 int8_t radio_getFrequencyOffset(void) {
@@ -263,6 +268,7 @@ void radio_loadPacket(uint8_t *packet, uint16_t len) {
 
 void radio_txEnable(void) {
 
+    radio_vars.radio_txrx_enabled = true;
     // change state
     radio_vars.state = RADIOSTATE_ENABLING_TX;
 
@@ -303,6 +309,7 @@ void radio_txNow(void) {
 
 void radio_rxEnable(void) {
 
+    radio_vars.radio_txrx_enabled = true;
     // change state
     radio_vars.state = RADIOSTATE_ENABLING_RX;
 

--- a/bsp/boards/radio.h
+++ b/bsp/boards/radio.h
@@ -86,6 +86,8 @@ void                radio_getReceivedFrame(uint8_t* bufRead,
                                 uint8_t* lqi,
                                    bool* crc);
 
+bool radio_is_enabled(void);
+
 // interrupt handlers
 kick_scheduler_t    radio_isr(void);
 

--- a/inc/check_config.h
+++ b/inc/check_config.h
@@ -52,6 +52,13 @@
 #error 'Hardware encryption not supported on this platform.'
 #endif
 
+#if BOARD_DEEP_SLEEP && (\
+    !defined(OPENMOTE_CC2538) && \
+    !defined(OPENMOTE_B) && \
+    !defined(OPENMOTE_B_24GHZ))
+#error 'DEEP_SLEEP is not configured for this platform.'
+#endif
+
 #if OPENWSN_IEEE802154E_SECURITY_C && !OPENWSN_CJOIN_C
 #error 'Link-layer security requires CJOIN application.'
 #endif

--- a/inc/config.h
+++ b/inc/config.h
@@ -422,6 +422,17 @@
 #endif
 
 /**
+ * \def BOARD_DEEP_SLEEP
+ *
+ * Enable deeper sleep for BOARDs that support it. This might hinder serial
+ * operation.
+ *
+ */
+#ifndef BOARD_DEEP_SLEEP
+#define BOARD_DEEP_SLEEP (0)
+#endif
+
+/**
  * \def BOARD_FASTSIM_ENABLED
  *
  * Enables fast UART printing in simulation mode. Active by default.


### PR DESCRIPTION
This PR adds an option to configure deeper sleep modes for a specific BOARD. Whenever a task is being ran the mode is blocked. Its also blocked whenever the radio is enabled. This mode will have
an impact on serial operation, so do not enable when debugging.

Its only configured for some `openmote-b` platforms.