### PR TITLE
inc/config: make coap port configurable

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -214,6 +214,15 @@
 #define OPENWSN_COAP_C (0)
 #endif
 
+/**
+ * \def OPENWSN_COAP_PORT_DEFAULT
+ *
+ * Defines the default port to use for COAP
+ *
+ */
+#ifndef OPENWSN_COAP_PORT_DEFAULT
+#define OPENWSN_COAP_PORT_DEFAULT   (5683)
+#endif
 
 // ========================== Stack modules ===========================
 

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -98,7 +98,7 @@ enum {
 // warning: first 4 MSB of 2° octet may coincide with previous protocol number
 enum {
     //UDP
-    WKP_UDP_COAP = 5683,
+    WKP_UDP_COAP = OPENWSN_COAP_PORT_DEFAULT,
     WKP_UDP_ECHO = 7,
     WKP_UDP_EXPIRATION = 5,
     WKP_UDP_MONITOR = 3,


### PR DESCRIPTION
This PR wants to make the default COAP configurable. Needed uit when using both RIOT's coap and OpenWSN since they both default to 5683 (RIOT's default is already configurable but would be nice to have this one as well.)