### PR TITLE
Hot fix: Remove var declaration within for loop.

### DIFF
--- a/openstack/04-TRAN/sock.c
+++ b/openstack/04-TRAN/sock.c
@@ -330,11 +330,12 @@ static void _sock_get_local_addr(open_addr_t* local) {
 static bool _sock_valid_addr(sock_udp_ep_t* ep) {
     uint8_t zero_count;
     const uint8_t* p;
+    uint8_t i;
 
     p = (uint8_t* )&ep->addr;
     zero_count = 0;
 
-    for (uint8_t i = 0; i < sizeof(ep->addr); i++) {
+    for (i = 0; i < sizeof(ep->addr); i++) {
         if (p [i] == 0) {
             zero_count++;
         }


### PR DESCRIPTION
Build on openmote-b currently fails due to the variable declaration within a for loop:

```scons: Building targets ...
Compiling          build/openmote-b-24ghz_armgcc/openstack/04-TRAN/sock.o
build/openmote-b-24ghz_armgcc/openstack/04-TRAN/sock.c: In function '_sock_valid_addr':
build/openmote-b-24ghz_armgcc/openstack/04-TRAN/sock.c:337:5: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
     for (uint8_t i = 0; i < sizeof(ep->addr); i++) {
     ^
build/openmote-b-24ghz_armgcc/openstack/04-TRAN/sock.c:337:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
scons: *** [build/openmote-b-24ghz_armgcc/openstack/04-TRAN/sock.o] Error 1
scons: building terminated because of errors.
```

This is a simple fix to remove that declaration.